### PR TITLE
Implement dynamic sizing for `0-6` public inputs in Groth16 verification

### DIFF
--- a/pairing-utils/src/bin/convert_from_snarkjs.rs
+++ b/pairing-utils/src/bin/convert_from_snarkjs.rs
@@ -1,0 +1,334 @@
+//! This tool converts Groth16 proofs and verification keys from snarkjs format to the
+//! o1js-blobstream format used by the "proof conversion" system.
+//!
+//! ## Usage
+//!
+//! ```bash
+//! cargo run --bin convert_from_snarkjs <proof.json> <public.json> <vk.json> <output_proof.json> <output_vk.json>
+//! ```
+//!
+//! ## Arguments
+//!
+//! - `proof.json`: snarkjs proof file
+//! - `public.json`: public inputs file
+//! - `vk.json`: snarkjs verification key file
+//! - `output_proof.json`: output o1js-blobstream format proof file
+//! - `output_vk.json`: output o1js-blobstream format verification key file
+
+//! ## What it does
+//!
+//! 1. **Proof conversion**: Converts snarkjs proof format to o1js-blobstream format
+//!    - Negates pi_a using arkworks for proper G1 point negation
+//!    - Converts pi_b to G2 format
+//!    - Converts pi_c to G1 format
+//!    - Maps public inputs to pi1-pi5 fields
+//!
+//! 2. **Verification key conversion**: Converts snarkjs VK to o1js-blobstream format
+//!    - Converts alpha, beta, gamma, delta points to named fields
+//!    - Computes alpha-beta pairing `e(α, β) ∈ Fp12` using arkworks `multi_miller_loop`
+//!    - Adds hardcoded w27 for pairing optimizations
+//!    - Maps IC points to ic0-ic5 format
+//!
+//! ## Input format requirements
+//!
+//! - VK nPublic must match the number of public inputs
+//! - VK IC points must equal public inputs + 1 (for the constant)
+//! - Works with circuits that have exactly 5 public inputs (due to Risc0 pi computation in o1js-blobstream format)
+//! - All files must be valid JSON
+
+use ark_bn254::{Bn254, Fq, Fq12, Fq2, G1Affine, G2Affine};
+use ark_ec::pairing::Pairing;
+use ark_ec::AffineRepr;
+use ark_ff::{PrimeField, Zero};
+use num_bigint::BigUint;
+use serde::{Deserialize, Serialize};
+use serde_json;
+use std::env;
+use std::fs;
+use std::str::FromStr;
+
+#[derive(Deserialize, Debug)]
+struct SnarkjsProof {
+    pi_a: Vec<String>,
+    pi_b: Vec<Vec<String>>,
+    pi_c: Vec<String>,
+}
+
+#[derive(Deserialize, Debug)]
+struct SnarkjsVK {
+    #[serde(rename = "nPublic")]
+    n_public: usize,
+    vk_alpha_1: Vec<String>,
+    vk_beta_2: Vec<Vec<String>>,
+    vk_gamma_2: Vec<Vec<String>>,
+    vk_delta_2: Vec<Vec<String>>,
+    #[serde(rename = "IC")]
+    ic: Vec<Vec<String>>,
+}
+
+#[derive(Serialize, Debug)]
+struct O1jsProof {
+    #[serde(rename = "negA")]
+    neg_a: G1Point,
+    #[serde(rename = "B")]
+    b: G2Point,
+    #[serde(rename = "C")]
+    c: G1Point,
+    pi1: String,
+    pi2: String,
+    pi3: String,
+    pi4: String,
+    pi5: String,
+}
+
+#[derive(Serialize, Debug)]
+struct G1Point {
+    x: String,
+    y: String,
+}
+
+#[derive(Serialize, Debug)]
+struct G2Point {
+    x_c0: String,
+    x_c1: String,
+    y_c0: String,
+    y_c1: String,
+}
+
+#[derive(Serialize, Debug)]
+struct Fp12Element {
+    g00: String,
+    g01: String,
+    g10: String,
+    g11: String,
+    g20: String,
+    g21: String,
+    h00: String,
+    h01: String,
+    h10: String,
+    h11: String,
+    h20: String,
+    h21: String,
+}
+
+#[derive(Serialize, Debug)]
+struct O1jsVK {
+    alpha: G1Point,
+    beta: G2Point,
+    gamma: G2Point,
+    delta: G2Point,
+    alpha_beta: Fp12Element,
+    w27: Fp12Element,
+    ic0: G1Point,
+    ic1: G1Point,
+    ic2: G1Point,
+    ic3: G1Point,
+    ic4: G1Point,
+    ic5: G1Point,
+}
+
+fn negate_g1_point(point: &[String]) -> G1Point {
+    let x_val = BigUint::parse_bytes(point[0].as_bytes(), 10).unwrap();
+    let y_val = BigUint::parse_bytes(point[1].as_bytes(), 10).unwrap();
+
+    let x_fq = Fq::from_str(&x_val.to_str_radix(10)).unwrap();
+    let y_fq = Fq::from_str(&y_val.to_str_radix(10)).unwrap();
+
+    let g1_point = G1Affine::new(x_fq, y_fq);
+    let neg_point = -g1_point;
+
+    G1Point {
+        x: neg_point.x().unwrap().into_bigint().to_string(),
+        y: neg_point.y().unwrap().into_bigint().to_string(),
+    }
+}
+
+fn convert_g1_point(point: &[String]) -> G1Point {
+    G1Point {
+        x: point[0].clone(),
+        y: point[1].clone(),
+    }
+}
+
+fn convert_g2_point(point: &[Vec<String>]) -> G2Point {
+    G2Point {
+        x_c0: point[0][0].clone(),
+        x_c1: point[0][1].clone(),
+        y_c0: point[1][0].clone(),
+        y_c1: point[1][1].clone(),
+    }
+}
+
+// Hardcoded w27 (used for pairing optimizations)
+// https://eprint.iacr.org/2024/640
+fn create_default_w27() -> Fp12Element {
+    Fp12Element {
+        g00: "0".to_string(),
+        g01: "0".to_string(),
+        g10: "0".to_string(),
+        g11: "0".to_string(),
+        g20: "8204864362109909869166472767738877274689483185363591877943943203703805152849"
+            .to_string(),
+        g21: "17912368812864921115467448876996876278487602260484145953989158612875588124088"
+            .to_string(),
+        h00: "0".to_string(),
+        h01: "0".to_string(),
+        h10: "0".to_string(),
+        h11: "0".to_string(),
+        h20: "0".to_string(),
+        h21: "0".to_string(),
+    }
+}
+
+fn serialize_fq12(f: Fq12) -> Fp12Element {
+    let to_string = |x: Fq| -> String {
+        if x == Fq::zero() {
+            "0".to_string()
+        } else {
+            x.to_string()
+        }
+    };
+
+    Fp12Element {
+        g00: to_string(f.c0.c0.c0),
+        g01: to_string(f.c0.c0.c1),
+        g10: to_string(f.c0.c1.c0),
+        g11: to_string(f.c0.c1.c1),
+        g20: to_string(f.c0.c2.c0),
+        g21: to_string(f.c0.c2.c1),
+        h00: to_string(f.c1.c0.c0),
+        h01: to_string(f.c1.c0.c1),
+        h10: to_string(f.c1.c1.c0),
+        h11: to_string(f.c1.c1.c1),
+        h20: to_string(f.c1.c2.c0),
+        h21: to_string(f.c1.c2.c1),
+    }
+}
+
+fn compute_alpha_beta_pairing(alpha: &[String], beta: &[Vec<String>]) -> Fp12Element {
+    // Parse alpha (G1)
+    let alpha_x: Fq = Fq::from_str(alpha[0].as_str()).unwrap();
+    let alpha_y: Fq = Fq::from_str(alpha[1].as_str()).unwrap();
+
+    // Parse beta (G2)
+    let beta_x_c0: Fq = Fq::from_str(beta[0][0].as_str()).unwrap();
+    let beta_x_c1: Fq = Fq::from_str(beta[0][1].as_str()).unwrap();
+    let beta_y_c0: Fq = Fq::from_str(beta[1][0].as_str()).unwrap();
+    let beta_y_c1: Fq = Fq::from_str(beta[1][1].as_str()).unwrap();
+
+    let beta_x = Fq2::new(beta_x_c0, beta_x_c1);
+    let beta_y = Fq2::new(beta_y_c0, beta_y_c1);
+
+    let alpha_g1 = G1Affine::new(alpha_x, alpha_y);
+    let beta_g2 = G2Affine::new(beta_x, beta_y);
+
+    // Compute pairing
+    let alpha_beta = Bn254::multi_miller_loop(&[alpha_g1], &[beta_g2]).0;
+
+    serialize_fq12(alpha_beta)
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args: Vec<String> = env::args().collect();
+
+    if args.len() != 6 {
+        eprintln!(
+            "Usage: {} <proof.json> <public.json> <vk.json> <output_proof.json> <output_vk.json>",
+            args[0]
+        );
+        eprintln!("Example: {} proof.json public.json vk.json converted_proof.json converted_vk.json", args[0]);
+        std::process::exit(1);
+    }
+
+    let proof_path = &args[1];
+    let public_path = &args[2];
+    let vk_path = &args[3];
+    let output_proof_path = &args[4];
+    let output_vk_path = &args[5];
+
+    // Read proof.json
+    let proof_content = fs::read_to_string(proof_path)?;
+    let snarkjs_proof: SnarkjsProof = serde_json::from_str(&proof_content)?;
+
+    // Read public.json
+    let public_content = fs::read_to_string(public_path)?;
+    let public_inputs: Vec<String> = serde_json::from_str(&public_content)?;
+
+    // Read verification_key.json
+    let vk_content = fs::read_to_string(vk_path)?;
+    let snarkjs_vk: SnarkjsVK = serde_json::from_str(&vk_content)?;
+
+    // Amount of public inputs in the verification key (nPublic) should be equal to amount of public inputs in the public.json file
+    if snarkjs_vk.n_public != public_inputs.len() {
+        eprintln!(
+            "❌ VK nPublic ({}) doesn't match public inputs ({})",
+            snarkjs_vk.n_public,
+            public_inputs.len()
+        );
+        std::process::exit(1);
+    }
+
+    // Input commitment points in the verification key file should be equal to amount of public inputs in the public.json file + 1 (the constant)
+    if snarkjs_vk.ic.len() != public_inputs.len() + 1 {
+        eprintln!(
+            "❌ VK IC points ({}) should be {}",
+            snarkjs_vk.ic.len(),
+            public_inputs.len() + 1
+        );
+        std::process::exit(1);
+    }
+
+    // Convert proof to o1js format
+    let o1js_proof = O1jsProof {
+        neg_a: negate_g1_point(&snarkjs_proof.pi_a), // pi_a is negated here
+        b: convert_g2_point(&snarkjs_proof.pi_b),
+        c: convert_g1_point(&snarkjs_proof.pi_c),
+        pi1: public_inputs.get(0).unwrap_or(&"0".to_string()).clone(),
+        pi2: public_inputs.get(1).unwrap_or(&"0".to_string()).clone(),
+        pi3: public_inputs.get(2).unwrap_or(&"0".to_string()).clone(),
+        pi4: public_inputs.get(3).unwrap_or(&"0".to_string()).clone(),
+        pi5: public_inputs.get(4).unwrap_or(&"0".to_string()).clone(),
+    };
+
+    // Convert VK to o1js format
+    let o1js_vk = O1jsVK {
+        alpha: convert_g1_point(&snarkjs_vk.vk_alpha_1),
+        beta: convert_g2_point(&snarkjs_vk.vk_beta_2),
+        gamma: convert_g2_point(&snarkjs_vk.vk_gamma_2),
+        delta: convert_g2_point(&snarkjs_vk.vk_delta_2),
+        alpha_beta: compute_alpha_beta_pairing(&snarkjs_vk.vk_alpha_1, &snarkjs_vk.vk_beta_2),
+        w27: create_default_w27(),
+        ic0: convert_g1_point(&snarkjs_vk.ic[0]),
+        ic1: convert_g1_point(&snarkjs_vk.ic[1]),
+        ic2: convert_g1_point(&snarkjs_vk.ic[2]),
+        ic3: convert_g1_point(&snarkjs_vk.ic[3]),
+        ic4: convert_g1_point(&snarkjs_vk.ic[4]),
+        ic5: convert_g1_point(&snarkjs_vk.ic[5]),
+    };
+
+    // Write outputs
+    let proof_json = serde_json::to_string_pretty(&o1js_proof)?;
+    let vk_json = serde_json::to_string_pretty(&o1js_vk)?;
+
+    fs::write(output_proof_path, proof_json)?;
+    fs::write(output_vk_path, vk_json)?;
+
+    println!("✅ Successfully converted to o1js-blobstream format:");
+    println!("📁 Input proof: {}", proof_path);
+    println!("📁 Input public: {}", public_path);
+    println!("📁 Input VK: {}", vk_path);
+    println!("📁 Output proof: {}", output_proof_path);
+    println!("📁 Output VK: {}", output_vk_path);
+    println!("🔧 Applied negation to pi_a using arkworks");
+    println!("🔧 Computed alpha-beta pairing using arkworks");
+    println!(
+        "🔧 Converted {} public inputs to pi1-pi5 format",
+        public_inputs.len()
+    );
+    println!(
+        "🔧 Converted {} IC points to ic0-ic5 format",
+        snarkjs_vk.ic.len()
+    );
+
+    Ok(())
+}

--- a/src/groth/compute_pi.ts
+++ b/src/groth/compute_pi.ts
@@ -2,54 +2,23 @@ import { GrothVk } from './vk.js';
 import { bn254 } from '../ec/g1.js';
 import { FrC } from '../towers/fr.js';
 import { ForeignCurve } from 'o1js';
-import { CONFIG } from './config.js';
 
-// pis are sent without beginning 1
+// Groth16 public input computation: PI = IC[0] + Σ(pis[i] * IC[i+1])
+// pis array contains only the actual public inputs (no leading "1" constant)
+// IC[0] is the constant term, IC[1] multiplies pis[0], IC[2] multiplies pis[1], etc.
 export function computePI(VK: GrothVk, pis: Array<FrC>): ForeignCurve {
-  if (pis.length !== CONFIG.publicInputCount) {
-    throw new Error(`Expected exactly ${CONFIG.publicInputCount} public inputs, got ${pis.length}`);
-  }
+  const actualInputCount = pis.length;
   
+  // Start with IC[0] constant term
   let acc = new bn254({ x: VK.ic0.x, y: VK.ic0.y });
-  switch (CONFIG.publicInputCount) {
-    case 0:
-      // Only ic0, no additional inputs
-      break;
-    case 1:
-      acc = acc.add(VK.ic1.scale(pis[0]));
-      break;
-    case 2:
-      acc = acc.add(VK.ic1.scale(pis[0]));
-      acc = acc.add(VK.ic2.scale(pis[1]));
-      break;
-    case 3:
-      acc = acc.add(VK.ic1.scale(pis[0]));
-      acc = acc.add(VK.ic2.scale(pis[1]));
-      acc = acc.add(VK.ic3.scale(pis[2]));
-      break;
-    case 4:
-      acc = acc.add(VK.ic1.scale(pis[0]));
-      acc = acc.add(VK.ic2.scale(pis[1]));
-      acc = acc.add(VK.ic3.scale(pis[2]));
-      acc = acc.add(VK.ic4.scale(pis[3]));
-      break;
-    case 5:
-      acc = acc.add(VK.ic1.scale(pis[0]));
-      acc = acc.add(VK.ic2.scale(pis[1]));
-      acc = acc.add(VK.ic3.scale(pis[2]));
-      acc = acc.add(VK.ic4.scale(pis[3]));
-      acc = acc.add(VK.ic5.scale(pis[4]));
-      break;
-    case 6:
-      acc = acc.add(VK.ic1.scale(pis[0]));
-      acc = acc.add(VK.ic2.scale(pis[1]));
-      acc = acc.add(VK.ic3.scale(pis[2]));
-      acc = acc.add(VK.ic4.scale(pis[3]));
-      acc = acc.add(VK.ic5.scale(pis[4]));
-      acc = acc.add(VK.ic6.scale(pis[5]));
-      break;
-    default:
-      throw new Error(`Unsupported input count: ${CONFIG.publicInputCount}`);
+  
+  // Add Σ(pis[i] * IC[i+1]) for i = 0 to actualInputCount-1
+  for (let i = 0; i < actualInputCount; i++) {
+    const icPoint = VK.getIcPoint(i + 1); // IC[1], IC[2], IC[3], etc.
+    if (!icPoint) {
+      throw new Error(`VK missing IC point ic${i + 1} for public input ${i}`);
+    }
+    acc = acc.add(icPoint.scale(pis[i])); // pis[i] * IC[i+1]
   }
 
   return acc;

--- a/src/groth/compute_pi.ts
+++ b/src/groth/compute_pi.ts
@@ -1,18 +1,56 @@
 import { GrothVk } from './vk.js';
-import { Proof } from './proof.js';
 import { bn254 } from '../ec/g1.js';
 import { FrC } from '../towers/fr.js';
 import { ForeignCurve } from 'o1js';
+import { CONFIG } from './config.js';
 
 // pis are sent without beginning 1
 export function computePI(VK: GrothVk, pis: Array<FrC>): ForeignCurve {
+  if (pis.length !== CONFIG.publicInputCount) {
+    throw new Error(`Expected exactly ${CONFIG.publicInputCount} public inputs, got ${pis.length}`);
+  }
+  
   let acc = new bn254({ x: VK.ic0.x, y: VK.ic0.y });
-
-  acc = acc.add(VK.ic1.scale(pis[0]));
-  acc = acc.add(VK.ic2.scale(pis[1]));
-  acc = acc.add(VK.ic3.scale(pis[2]));
-  acc = acc.add(VK.ic4.scale(pis[3]));
-  acc = acc.add(VK.ic5.scale(pis[4]));
+  switch (CONFIG.publicInputCount) {
+    case 0:
+      // Only ic0, no additional inputs
+      break;
+    case 1:
+      acc = acc.add(VK.ic1.scale(pis[0]));
+      break;
+    case 2:
+      acc = acc.add(VK.ic1.scale(pis[0]));
+      acc = acc.add(VK.ic2.scale(pis[1]));
+      break;
+    case 3:
+      acc = acc.add(VK.ic1.scale(pis[0]));
+      acc = acc.add(VK.ic2.scale(pis[1]));
+      acc = acc.add(VK.ic3.scale(pis[2]));
+      break;
+    case 4:
+      acc = acc.add(VK.ic1.scale(pis[0]));
+      acc = acc.add(VK.ic2.scale(pis[1]));
+      acc = acc.add(VK.ic3.scale(pis[2]));
+      acc = acc.add(VK.ic4.scale(pis[3]));
+      break;
+    case 5:
+      acc = acc.add(VK.ic1.scale(pis[0]));
+      acc = acc.add(VK.ic2.scale(pis[1]));
+      acc = acc.add(VK.ic3.scale(pis[2]));
+      acc = acc.add(VK.ic4.scale(pis[3]));
+      acc = acc.add(VK.ic5.scale(pis[4]));
+      break;
+    case 6:
+      acc = acc.add(VK.ic1.scale(pis[0]));
+      acc = acc.add(VK.ic2.scale(pis[1]));
+      acc = acc.add(VK.ic3.scale(pis[2]));
+      acc = acc.add(VK.ic4.scale(pis[3]));
+      acc = acc.add(VK.ic5.scale(pis[4]));
+      acc = acc.add(VK.ic6.scale(pis[5]));
+      break;
+    default:
+      throw new Error(`Unsupported input count: ${CONFIG.publicInputCount}`);
+  }
 
   return acc;
 }

--- a/src/groth/config.ts
+++ b/src/groth/config.ts
@@ -1,54 +1,18 @@
 /**
- * Build-time configuration for public input count
- * Set via PUBLIC_INPUT_COUNT environment variable
- */
-
-const PUBLIC_INPUT_COUNT = parseInt(process.env.PUBLIC_INPUT_COUNT || '5');
-
-if (PUBLIC_INPUT_COUNT < 0 || PUBLIC_INPUT_COUNT > 6) {
-    throw new Error(`Invalid PUBLIC_INPUT_COUNT: ${PUBLIC_INPUT_COUNT}. Supported range: 0-6`);
-}
-
-/**
- * Distribution strategy for zkp14/zkp15 based on empirical testing:
+ * Distribution strategy for zkp14/zkp15:
  * - 6 inputs: 3+3 distribution
  * - 5 inputs: 3+2 distribution (RISC0 setup)
  * - Lower counts: Keep all in zkp14 to minimize zkp15 complexity
  */
-function getDistribution(inputCount: number): { zkp14: number[], zkp15: number[] } {
+export function getDistribution(inputCount: number): { zkp14: number[], zkp15: number[] } {
     switch (inputCount) {
         case 0: return { zkp14: [], zkp15: [] }; // Only ic0, no public inputs
         case 1: return { zkp14: [0], zkp15: [] }; // zkp14 handles pis[0]
         case 2: return { zkp14: [0, 1], zkp15: [] }; // zkp14 handles pis[0], pis[1]
         case 3: return { zkp14: [0, 1, 2], zkp15: [] }; // zkp14 handles pis[0], pis[1], pis[2]
-        case 4: return { zkp14: [0, 1], zkp15: [2, 3] }; // 2+2
+        case 4: return { zkp14: [0, 1, 2], zkp15: [3] }; // 3+1
         case 5: return { zkp14: [0, 1, 2], zkp15: [3, 4] }; // 3 + 2 (RISC0 setup)
         case 6: return { zkp14: [0, 1, 2], zkp15: [3, 4, 5] }; // 3 + 3
         default: throw new Error(`Unsupported input count: ${inputCount}`);
     }
 }
-
-/**
- * Generate field names for proof parsing
- */
-function getProofFields(inputCount: number): string[] {
-    return Array.from({ length: inputCount }, (_, i) => `pi${i + 1}`);
-}
-
-/**
- * Generate IC point names for VK parsing
- */
-function getIcFields(inputCount: number): string[] {
-    return Array.from({ length: inputCount + 1 }, (_, i) => `ic${i}`);
-}
-
-export const CONFIG = {
-    publicInputCount: PUBLIC_INPUT_COUNT,
-    distribution: getDistribution(PUBLIC_INPUT_COUNT),
-    proofFields: getProofFields(PUBLIC_INPUT_COUNT),
-    icFields: getIcFields(PUBLIC_INPUT_COUNT),
-} as const;
-
-// Type exports for compile-time type safety
-export type PublicInputCount = typeof CONFIG.publicInputCount;
-export type Distribution = typeof CONFIG.distribution;

--- a/src/groth/config.ts
+++ b/src/groth/config.ts
@@ -1,0 +1,54 @@
+/**
+ * Build-time configuration for public input count
+ * Set via PUBLIC_INPUT_COUNT environment variable
+ */
+
+const PUBLIC_INPUT_COUNT = parseInt(process.env.PUBLIC_INPUT_COUNT || '5');
+
+if (PUBLIC_INPUT_COUNT < 0 || PUBLIC_INPUT_COUNT > 6) {
+    throw new Error(`Invalid PUBLIC_INPUT_COUNT: ${PUBLIC_INPUT_COUNT}. Supported range: 0-6`);
+}
+
+/**
+ * Distribution strategy for zkp14/zkp15 based on empirical testing:
+ * - 6 inputs: 3+3 distribution
+ * - 5 inputs: 3+2 distribution (RISC0 setup)
+ * - Lower counts: Keep all in zkp14 to minimize zkp15 complexity
+ */
+function getDistribution(inputCount: number): { zkp14: number[], zkp15: number[] } {
+    switch (inputCount) {
+        case 0: return { zkp14: [], zkp15: [] }; // Only ic0, no public inputs
+        case 1: return { zkp14: [0], zkp15: [] }; // zkp14 handles pis[0]
+        case 2: return { zkp14: [0, 1], zkp15: [] }; // zkp14 handles pis[0], pis[1]
+        case 3: return { zkp14: [0, 1, 2], zkp15: [] }; // zkp14 handles pis[0], pis[1], pis[2]
+        case 4: return { zkp14: [0, 1], zkp15: [2, 3] }; // 2+2
+        case 5: return { zkp14: [0, 1, 2], zkp15: [3, 4] }; // 3 + 2 (RISC0 setup)
+        case 6: return { zkp14: [0, 1, 2], zkp15: [3, 4, 5] }; // 3 + 3
+        default: throw new Error(`Unsupported input count: ${inputCount}`);
+    }
+}
+
+/**
+ * Generate field names for proof parsing
+ */
+function getProofFields(inputCount: number): string[] {
+    return Array.from({ length: inputCount }, (_, i) => `pi${i + 1}`);
+}
+
+/**
+ * Generate IC point names for VK parsing
+ */
+function getIcFields(inputCount: number): string[] {
+    return Array.from({ length: inputCount + 1 }, (_, i) => `ic${i}`);
+}
+
+export const CONFIG = {
+    publicInputCount: PUBLIC_INPUT_COUNT,
+    distribution: getDistribution(PUBLIC_INPUT_COUNT),
+    proofFields: getProofFields(PUBLIC_INPUT_COUNT),
+    icFields: getIcFields(PUBLIC_INPUT_COUNT),
+} as const;
+
+// Type exports for compile-time type safety
+export type PublicInputCount = typeof CONFIG.publicInputCount;
+export type Distribution = typeof CONFIG.distribution;

--- a/src/groth/e2e_test.ts
+++ b/src/groth/e2e_test.ts
@@ -4,7 +4,9 @@ import { Groth16Verifier } from './verifier.js';
 const grothVerifier = new Groth16Verifier('./src/groth/example_jsons/vk.json');
 
 function main() {
-  const proof = parseProof(grothVerifier.vk, './src/groth/example_jsons/proof.json');
+  const proof = Provable.witness(Proof, () =>
+    parseProof(grothVerifier.vk, './src/groth/example_jsons/proof.json')
+  );
   const aux_witness = Provable.witness(AuXWitness, () =>
     AuXWitness.parse('./src/groth/example_jsons/aux_witness.json')
   );
@@ -13,7 +15,7 @@ function main() {
 
 // npm run build && node --max-old-space-size=65536 build/src/groth/e2e_test.js
 import v8 from 'v8';
-import { parseProof } from './proof.js';
+import { parseProof, Proof } from './proof.js';
 import { AuXWitness } from '../aux_witness.js';
 (async () => {
   console.time('running Fp constant version');

--- a/src/groth/e2e_test.ts
+++ b/src/groth/e2e_test.ts
@@ -4,9 +4,7 @@ import { Groth16Verifier } from './verifier.js';
 const grothVerifier = new Groth16Verifier('./src/groth/example_jsons/vk.json');
 
 function main() {
-  const proof = Provable.witness(Proof, () =>
-    Proof.parse(grothVerifier.vk, './src/groth/example_jsons/proof.json')
-  );
+  const proof = parseProof(grothVerifier.vk, './src/groth/example_jsons/proof.json');
   const aux_witness = Provable.witness(AuXWitness, () =>
     AuXWitness.parse('./src/groth/example_jsons/aux_witness.json')
   );
@@ -15,7 +13,7 @@ function main() {
 
 // npm run build && node --max-old-space-size=65536 build/src/groth/e2e_test.js
 import v8 from 'v8';
-import { Proof } from './proof.js';
+import { parseProof } from './proof.js';
 import { AuXWitness } from '../aux_witness.js';
 (async () => {
   console.time('running Fp constant version');

--- a/src/groth/proof.ts
+++ b/src/groth/proof.ts
@@ -5,6 +5,7 @@ import { Provable, Struct } from 'o1js';
 import { G2Line, computeLineCoeffs } from '../lines/index.js';
 import { computePI } from './compute_pi.js';
 import { GrothVk } from './vk.js';
+import { CONFIG } from './config.js';
 
 const getNumOfLines = () => {
   let cnt = 0;
@@ -18,7 +19,8 @@ const getNumOfLines = () => {
   return cnt + 2;
 };
 
-type SerializedProof = {
+// Dynamic `SerializedProof` type based on `CONFIG.publicInputCount`
+type SerializedProofBase = {
   negA: {
     x: string;
     y: string;
@@ -33,11 +35,16 @@ type SerializedProof = {
     x: string;
     y: string;
   };
-  pi1: string;
-  pi2: string;
-  pi3: string;
-  pi4: string;
-  pi5: string;
+};
+
+// Flexible `SerializedProof` type supporting all possible public input fields
+type SerializedProof = SerializedProofBase & {
+  pi1?: string;
+  pi2?: string;
+  pi3?: string;
+  pi4?: string;
+  pi5?: string;
+  pi6?: string;
 };
 
 class Proof extends Struct({
@@ -46,11 +53,18 @@ class Proof extends Struct({
   C: G1Affine,
   PI: G1Affine,
   b_lines: Provable.Array(G2Line, getNumOfLines()),
-  pis: Provable.Array(FrC.provable, 5),
+  pis: Provable.Array(FrC.provable, CONFIG.publicInputCount),
 }) {
   static parse(vk: GrothVk, path: string): Proof {
     const data = fs.readFileSync(path, 'utf-8');
     const obj: SerializedProof = JSON.parse(data);
+
+    // Validate expected public inputs are present
+    for (const field of CONFIG.proofFields) {
+      if (!(field in obj)) {
+        throw new Error(`Missing required public input: ${field}`);
+      }
+    }
 
     const negA = new G1Affine({
       x: FpC.from(obj.negA.x),
@@ -58,13 +72,14 @@ class Proof extends Struct({
     });
     const C = new G1Affine({ x: FpC.from(obj.C.x), y: FpC.from(obj.C.y) });
 
-    const pis = [
-      FrC.from(obj.pi1),
-      FrC.from(obj.pi2),
-      FrC.from(obj.pi3),
-      FrC.from(obj.pi4),
-      FrC.from(obj.pi5),
-    ];
+    // Parse public inputs dynamically based on configuration
+    const pis = CONFIG.proofFields.map(field => {
+      const value = (obj as any)[field];
+      if (value === undefined) {
+        throw new Error(`Missing public input field: ${field}`);
+      }
+      return FrC.from(value);
+    });
     let piBn = computePI(vk, pis);
     const PI = new G1Affine({
       x: FpC.from(piBn.x).assertCanonical(),

--- a/src/groth/proof.ts
+++ b/src/groth/proof.ts
@@ -5,7 +5,15 @@ import { Provable, Struct } from 'o1js';
 import { G2Line, computeLineCoeffs } from '../lines/index.js';
 import { computePI } from './compute_pi.js';
 import { GrothVk } from './vk.js';
-import { CONFIG } from './config.js';
+
+export interface ProofData {
+  negA: G1Affine;
+  B: G2Affine;
+  C: G1Affine;
+  PI: G1Affine;
+  b_lines: G2Line[];
+  pis: FrC[];
+}
 
 const getNumOfLines = () => {
   let cnt = 0;
@@ -19,81 +27,95 @@ const getNumOfLines = () => {
   return cnt + 2;
 };
 
-// Dynamic `SerializedProof` type based on `CONFIG.publicInputCount`
-type SerializedProofBase = {
-  negA: {
-    x: string;
-    y: string;
-  };
-  B: {
-    x_c0: string;
-    x_c1: string;
-    y_c0: string;
-    y_c1: string;
-  };
-  C: {
-    x: string;
-    y: string;
-  };
-};
+// Cache for dynamically created Proof classes
+const proofClassCache = new Map<number, any>();
 
-// Flexible `SerializedProof` type supporting all possible public input fields
-type SerializedProof = SerializedProofBase & {
-  pi1?: string;
-  pi2?: string;
-  pi3?: string;
-  pi4?: string;
-  pi5?: string;
-  pi6?: string;
-};
-
-class Proof extends Struct({
-  negA: G1Affine,
-  B: G2Affine,
-  C: G1Affine,
-  PI: G1Affine,
-  b_lines: Provable.Array(G2Line, getNumOfLines()),
-  pis: Provable.Array(FrC.provable, CONFIG.publicInputCount),
-}) {
-  static parse(vk: GrothVk, path: string): Proof {
-    const data = fs.readFileSync(path, 'utf-8');
-    const obj: SerializedProof = JSON.parse(data);
-
-    // Validate expected public inputs are present
-    for (const field of CONFIG.proofFields) {
-      if (!(field in obj)) {
-        throw new Error(`Missing required public input: ${field}`);
-      }
-    }
-
-    const negA = new G1Affine({
-      x: FpC.from(obj.negA.x),
-      y: FpC.from(obj.negA.y),
-    });
-    const C = new G1Affine({ x: FpC.from(obj.C.x), y: FpC.from(obj.C.y) });
-
-    // Parse public inputs dynamically based on configuration
-    const pis = CONFIG.proofFields.map(field => {
-      const value = (obj as any)[field];
-      if (value === undefined) {
-        throw new Error(`Missing public input field: ${field}`);
-      }
-      return FrC.from(value);
-    });
-    let piBn = computePI(vk, pis);
-    const PI = new G1Affine({
-      x: FpC.from(piBn.x).assertCanonical(),
-      y: FpC.from(piBn.y).assertCanonical(),
-    });
-
-    const bx = new Fp2({ c0: FpC.from(obj.B.x_c0), c1: FpC.from(obj.B.x_c1) });
-    const by = new Fp2({ c0: FpC.from(obj.B.y_c0), c1: FpC.from(obj.B.y_c1) });
-    const B = new G2Affine({ x: bx, y: by });
-
-    const b_lines = computeLineCoeffs(B);
-
-    return new Proof({ negA, B, C, PI, b_lines, pis });
+function createProofClass(inputCount: number) {
+  if (inputCount < 0 || inputCount > 6) {
+    throw new Error(`Unsupported input count: ${inputCount}. Supported range: 0-6`);
   }
+
+  if (proofClassCache.has(inputCount)) {
+    return proofClassCache.get(inputCount);
+  }
+
+  const ProofClass = class extends Struct({
+    negA: G1Affine,
+    B: G2Affine,
+    C: G1Affine,
+    PI: G1Affine,
+    b_lines: Provable.Array(G2Line, getNumOfLines()),
+    pis: Provable.Array(FrC.provable, inputCount),
+  }) {
+    static parse(vk: GrothVk, path: string) {
+      const json = JSON.parse(fs.readFileSync(path, 'utf-8'));
+
+      // Get public inputs (pi1, pi2, etc)
+      const publicInputs: FrC[] = [];
+      for (let i = 1; i <= inputCount; i++) {
+        const key = `pi${i}`;
+        if (json[key]) {
+          publicInputs.push(FrC.from(json[key]));
+        }
+      }
+
+      const negA = new G1Affine({
+        x: FpC.from(json.negA.x),
+        y: FpC.from(json.negA.y),
+      });
+
+      const C = new G1Affine({
+        x: FpC.from(json.C.x),
+        y: FpC.from(json.C.y),
+      });
+
+      const B = new G2Affine({
+        x: new Fp2({
+          c0: FpC.from(json.B.x_c0),
+          c1: FpC.from(json.B.x_c1),
+        }),
+        y: new Fp2({
+          c0: FpC.from(json.B.y_c0),
+          c1: FpC.from(json.B.y_c1),
+        }),
+      });
+
+      const PI = new G1Affine({
+        x: FpC.from(computePI(vk, publicInputs).x).assertCanonical(),
+        y: FpC.from(computePI(vk, publicInputs).y).assertCanonical(),
+      });
+
+      return new ProofClass({
+        negA,
+        B,
+        C,
+        PI,
+        b_lines: computeLineCoeffs(B),
+        pis: publicInputs,
+      });
+    }
+  };
+
+  proofClassCache.set(inputCount, ProofClass);
+  return ProofClass;
 }
+
+export function detectInputCountFromProof(path: string): number {
+  const json = JSON.parse(fs.readFileSync(path, 'utf-8'));
+  let count = 0;
+  for (let i = 1; i <= 6; i++) {
+    if (json[`pi${i}`]) count++;
+  }
+  return count;
+}
+
+export function parseProof(vk: GrothVk, path: string) {
+  const inputCount = detectInputCountFromProof(path);
+  const ProofClass = createProofClass(inputCount);
+  return ProofClass.parse(vk, path);
+}
+
+// Legacy Proof for backward compatibility (fixed 5 inputs)
+const Proof = createProofClass(5);
 
 export { Proof };

--- a/src/groth/recursion/prove_zkps.ts
+++ b/src/groth/recursion/prove_zkps.ts
@@ -2,7 +2,7 @@ import { Poseidon, verify, Cache, Provable, Field } from 'o1js';
 import { zkp0 } from './zkp0.js';
 import fs from 'fs';
 import { AuXWitness } from '../../aux_witness.js';
-import { Proof } from '../proof.js';
+import { parseProof, detectInputCountFromProof } from '../proof.js';
 import { Accumulator } from './data.js';
 import { WitnessTracker } from '../witness_tracker.js';
 import { zkp1 } from './zkp1.js';
@@ -18,21 +18,25 @@ import { zkp10 } from './zkp10.js';
 import { zkp11 } from './zkp11.js';
 import { zkp12 } from './zkp12.js';
 import { zkp13 } from './zkp13.js';
-import { zkp14 } from './zkp14.js';
-import { zkp15 } from './zkp15.js';
+import { createZkp14 } from './zkp14.js';
+import { createZkp15 } from './zkp15.js';
 import { G1Affine } from '../../ec/index.js';
 import { FrC } from '../../towers/fr.js';
 import { VK } from '../vk_from_env.js';
-import { CONFIG } from '../config.js';
+import { getDistribution } from '../config.js';
 
 // npm run build && node build/src/groth/recursion/prove_zkps.js zkp0 ./src/groth/jsons/proof.json ./src/groth/jsons/aux_witness.json ../scripts/risc_zero_example/work_dir ../scripts/risc_zero_example/cache_dir
 
 const args = process.argv;
 
-const proof = Proof.parse(VK, args[3]);
+const proof = parseProof(VK, args[3]);
 const auxWitness = AuXWitness.parse(args[4]);
 const workDir = args[5];
 const cacheDir = args[6];
+
+const inputCount = detectInputCountFromProof(args[3]);
+const { zkp14 } = createZkp14(inputCount);
+const { zkp15 } = createZkp15(inputCount);
 
 const wt = new WitnessTracker(proof, auxWitness);
 const [acc_0, lines_0, all_b_lines] = wt.in0();
@@ -350,7 +354,11 @@ async function prove_zkp14() {
     .verificationKey;
 
   const cin14 = Poseidon.hashPacked(G1Affine, proof.PI);
-  const proof14 = await zkp14.compute(cin14, proof.pis);
+  const distribution = getDistribution(inputCount);
+  const zkp14Inputs = distribution.zkp14.map(index => proof.pis[index]);
+
+  // zkp14 needs access to ALL public inputs for the full pis_hash
+  const proof14 = await zkp14.compute(cin14, zkp14Inputs, proof.pis);
 
   const valid = await verify(proof14.proof, vk14);
   console.log('valid zkp14?: ', valid);
@@ -368,18 +376,24 @@ async function prove_zkp15() {
     .verificationKey;
 
   const pi_hash = Poseidon.hashPacked(G1Affine, proof.PI);
-  const pis_hash = Poseidon.hashPacked(
-    Provable.Array(FrC.provable, CONFIG.publicInputCount),
+  const distribution = getDistribution(inputCount);
+  const zkp15Inputs = distribution.zkp15.map((index: number) => proof.pis[index]);
+
+  const acc_hash = Poseidon.hashPacked(G1Affine, partialPiAcc);
+
+  // zkp15 input should match zkp14's output: hash([pi_hash, full_pis_hash, acc_hash])
+  // Both zkp14 and zkp15 use the SAME pis_hash (hash of ALL public inputs)
+  const full_pis_hash = Poseidon.hashPacked(
+    Provable.Array(FrC.provable, proof.pis.length),
     proof.pis
   );
-  const acc_hash = Poseidon.hashPacked(G1Affine, partialPiAcc);
 
   const cin15 = Poseidon.hashPacked(Provable.Array(Field, 3), [
     pi_hash,
-    pis_hash,
+    full_pis_hash,
     acc_hash,
   ]);
-  const proof15 = await zkp15.compute(cin15, proof.PI, partialPiAcc, proof.pis);
+  const proof15 = await zkp15.compute(cin15, proof.PI, partialPiAcc, zkp15Inputs, proof.pis);
 
   const valid = await verify(proof15.proof, vk15);
   console.log('valid zkp15?: ', valid);

--- a/src/groth/recursion/prove_zkps.ts
+++ b/src/groth/recursion/prove_zkps.ts
@@ -23,6 +23,7 @@ import { zkp15 } from './zkp15.js';
 import { G1Affine } from '../../ec/index.js';
 import { FrC } from '../../towers/fr.js';
 import { VK } from '../vk_from_env.js';
+import { CONFIG } from '../config.js';
 
 // npm run build && node build/src/groth/recursion/prove_zkps.js zkp0 ./src/groth/jsons/proof.json ./src/groth/jsons/aux_witness.json ../scripts/risc_zero_example/work_dir ../scripts/risc_zero_example/cache_dir
 
@@ -368,7 +369,7 @@ async function prove_zkp15() {
 
   const pi_hash = Poseidon.hashPacked(G1Affine, proof.PI);
   const pis_hash = Poseidon.hashPacked(
-    Provable.Array(FrC.provable, 5),
+    Provable.Array(FrC.provable, CONFIG.publicInputCount),
     proof.pis
   );
   const acc_hash = Poseidon.hashPacked(G1Affine, partialPiAcc);

--- a/src/groth/recursion/zkp14.ts
+++ b/src/groth/recursion/zkp14.ts
@@ -5,6 +5,7 @@ import { ArrayListHasher } from '../../array_list_hasher.js';
 import { VK } from '../vk_from_env.js';
 import { G1Affine } from '../../ec/index.js';
 import { bn254 } from '../../ec/g1.js';
+import { CONFIG } from '../config.js';
 
 const zkp14 = ZkProgram({
   name: 'zkp14',
@@ -12,20 +13,53 @@ const zkp14 = ZkProgram({
   publicOutput: Field,
   methods: {
     compute: {
-      privateInputs: [Provable.Array(FrC.provable, 5)],
+      privateInputs: [Provable.Array(FrC.provable, CONFIG.publicInputCount)],
       async method(input: Field, pis: Array<FrC>) {
         const pis_hash = Poseidon.hashPacked(
-          Provable.Array(FrC.provable, 5),
+          Provable.Array(FrC.provable, CONFIG.publicInputCount),
           pis
         );
 
         let acc = new bn254({ x: VK.ic0.x, y: VK.ic0.y });
-
-        acc = acc.add(VK.ic1.scale(pis[0]));
-        acc = acc.add(VK.ic2.scale(pis[1]));
-        acc = acc.add(VK.ic3.scale(pis[2]));
-        // acc = acc.add(VK.ic4.scale(pis[3]));
-        // acc = acc.add(VK.ic5.scale(pis[4]));
+        switch (CONFIG.publicInputCount) {
+          case 0:
+            // Only ic0, no additional inputs
+            break;
+          case 1:
+            // zkp14 handles [0]: ic1*pis[0]
+            acc = acc.add(VK.ic1.scale(pis[0]));
+            break;
+          case 2:
+            // zkp14 handles [0,1]: ic1*pis[0] + ic2*pis[1]
+            acc = acc.add(VK.ic1.scale(pis[0]));
+            acc = acc.add(VK.ic2.scale(pis[1]));
+            break;
+          case 3:
+            // zkp14 handles [0,1,2]: ic1*pis[0] + ic2*pis[1] + ic3*pis[2]
+            acc = acc.add(VK.ic1.scale(pis[0]));
+            acc = acc.add(VK.ic2.scale(pis[1]));
+            acc = acc.add(VK.ic3.scale(pis[2]));
+            break;
+          case 4:
+            // zkp14 handles [0,1]: ic1*pis[0] + ic2*pis[1] (2+2 distribution)
+            acc = acc.add(VK.ic1.scale(pis[0]));
+            acc = acc.add(VK.ic2.scale(pis[1]));
+            break;
+          case 5:
+            // zkp14 handles [0,1,2]: ic1*pis[0] + ic2*pis[1] + ic3*pis[2] (3+2 distribution)
+            acc = acc.add(VK.ic1.scale(pis[0]));
+            acc = acc.add(VK.ic2.scale(pis[1]));
+            acc = acc.add(VK.ic3.scale(pis[2]));
+            break;
+          case 6:
+            // zkp14 handles [0,1,2]: ic1*pis[0] + ic2*pis[1] + ic3*pis[2] (3+3 distribution)
+            acc = acc.add(VK.ic1.scale(pis[0]));
+            acc = acc.add(VK.ic2.scale(pis[1]));
+            acc = acc.add(VK.ic3.scale(pis[2]));
+            break;
+          default:
+            throw new Error(`Unsupported input count: ${CONFIG.publicInputCount}`);
+        }
 
         // assert that sum ic_i * pis[i] = PI
 

--- a/src/groth/recursion/zkp14.ts
+++ b/src/groth/recursion/zkp14.ts
@@ -1,85 +1,62 @@
 import { Field, Poseidon, Provable, ZkProgram } from 'o1js';
-import { Accumulator } from './data.js';
-import { Fp12, FrC } from '../../towers/index.js';
-import { ArrayListHasher } from '../../array_list_hasher.js';
+import { FrC } from '../../towers/index.js';
 import { VK } from '../vk_from_env.js';
 import { G1Affine } from '../../ec/index.js';
 import { bn254 } from '../../ec/g1.js';
-import { CONFIG } from '../config.js';
+import { getDistribution } from '../config.js';
 
-const zkp14 = ZkProgram({
-  name: 'zkp14',
-  publicInput: Field,
-  publicOutput: Field,
-  methods: {
-    compute: {
-      privateInputs: [Provable.Array(FrC.provable, CONFIG.publicInputCount)],
-      async method(input: Field, pis: Array<FrC>) {
-        const pis_hash = Poseidon.hashPacked(
-          Provable.Array(FrC.provable, CONFIG.publicInputCount),
-          pis
-        );
+// Factory function to create zkp14 with correct public input array size
+export function createZkp14(inputCount: number) {
+  const distribution = getDistribution(inputCount);
+  const zkp14InputCount = distribution.zkp14.length;
 
-        let acc = new bn254({ x: VK.ic0.x, y: VK.ic0.y });
-        switch (CONFIG.publicInputCount) {
-          case 0:
-            // Only ic0, no additional inputs
-            break;
-          case 1:
-            // zkp14 handles [0]: ic1*pis[0]
-            acc = acc.add(VK.ic1.scale(pis[0]));
-            break;
-          case 2:
-            // zkp14 handles [0,1]: ic1*pis[0] + ic2*pis[1]
-            acc = acc.add(VK.ic1.scale(pis[0]));
-            acc = acc.add(VK.ic2.scale(pis[1]));
-            break;
-          case 3:
-            // zkp14 handles [0,1,2]: ic1*pis[0] + ic2*pis[1] + ic3*pis[2]
-            acc = acc.add(VK.ic1.scale(pis[0]));
-            acc = acc.add(VK.ic2.scale(pis[1]));
-            acc = acc.add(VK.ic3.scale(pis[2]));
-            break;
-          case 4:
-            // zkp14 handles [0,1]: ic1*pis[0] + ic2*pis[1] (2+2 distribution)
-            acc = acc.add(VK.ic1.scale(pis[0]));
-            acc = acc.add(VK.ic2.scale(pis[1]));
-            break;
-          case 5:
-            // zkp14 handles [0,1,2]: ic1*pis[0] + ic2*pis[1] + ic3*pis[2] (3+2 distribution)
-            acc = acc.add(VK.ic1.scale(pis[0]));
-            acc = acc.add(VK.ic2.scale(pis[1]));
-            acc = acc.add(VK.ic3.scale(pis[2]));
-            break;
-          case 6:
-            // zkp14 handles [0,1,2]: ic1*pis[0] + ic2*pis[1] + ic3*pis[2] (3+3 distribution)
-            acc = acc.add(VK.ic1.scale(pis[0]));
-            acc = acc.add(VK.ic2.scale(pis[1]));
-            acc = acc.add(VK.ic3.scale(pis[2]));
-            break;
-          default:
-            throw new Error(`Unsupported input count: ${CONFIG.publicInputCount}`);
-        }
+  const zkp14 = ZkProgram({
+    name: `zkp14_${inputCount}inputs`,
+    publicInput: Field,
+    publicOutput: Field,
+    methods: {
+      compute: {
+        privateInputs: [Provable.Array(FrC.provable, zkp14InputCount), Provable.Array(FrC.provable, inputCount)],
+        async method(input: Field, zkp14_pis: Array<FrC>, full_pis: Array<FrC>) {
+          const pis_hash = Poseidon.hashPacked(
+            Provable.Array(FrC.provable, inputCount),
+            full_pis
+          );
 
-        // assert that sum ic_i * pis[i] = PI
+          let acc = new bn254({ x: VK.ic0.x, y: VK.ic0.y });
 
-        const acc_aff = new G1Affine({
-          x: acc.x.assertCanonical(),
-          y: acc.y.assertCanonical(),
-        });
-        const acc_hash = Poseidon.hashPacked(G1Affine, acc_aff);
+          // Handle inputs based on distribution strategy
+          for (let i = 0; i < zkp14InputCount; i++) {
+            const icIndex = distribution.zkp14[i] + 1; // ic1, ic2, etc.
+            const icPoint = VK.getIcPoint(icIndex);
+            if (!icPoint) {
+              throw new Error(`Missing IC point ic${icIndex} for zkp14 input ${i}`);
+            }
+            acc = acc.add(icPoint.scale(zkp14_pis[i]));
+          }
 
-        return {
-          publicOutput: Poseidon.hashPacked(Provable.Array(Field, 3), [
+          const acc_aff = new G1Affine({
+            x: acc.x.assertCanonical(),
+            y: acc.y.assertCanonical(),
+          });
+          const acc_hash = Poseidon.hashPacked(G1Affine, acc_aff);
+
+          const publicOutput = Poseidon.hashPacked(Provable.Array(Field, 3), [
             input,
             pis_hash,
             acc_hash,
-          ]),
-        };
+          ]);
+
+
+          return { publicOutput };
+        },
       },
     },
-  },
-});
+  });
 
-const ZKP14Proof = ZkProgram.Proof(zkp14);
+  return { zkp14, ZKP14Proof: ZkProgram.Proof(zkp14) };
+}
+
+// Default export for backwards compatibility (can be removed later)
+const { zkp14, ZKP14Proof } = createZkp14(5); // Default to 5 inputs for Risc0
 export { ZKP14Proof, zkp14 };

--- a/src/groth/recursion/zkp15.ts
+++ b/src/groth/recursion/zkp15.ts
@@ -5,6 +5,7 @@ import { ArrayListHasher } from '../../array_list_hasher.js';
 import { VK } from '../vk_from_env.js';
 import { G1Affine } from '../../ec/index.js';
 import { bn254 } from '../../ec/g1.js';
+import { CONFIG } from '../config.js';
 
 const zkp15 = ZkProgram({
   name: 'zkp15',
@@ -12,11 +13,13 @@ const zkp15 = ZkProgram({
   publicOutput: Field,
   methods: {
     compute: {
-      privateInputs: [G1Affine, G1Affine, Provable.Array(FrC.provable, 5)],
+      privateInputs: [G1Affine, G1Affine, Provable.Array(FrC.provable, CONFIG.publicInputCount)],
       async method(input: Field, PI: G1Affine, acc: G1Affine, pis: Array<FrC>) {
+        // Note: pis.length is validated at compile time by Provable.Array constraint
+
         const pi_hash = Poseidon.hashPacked(G1Affine, PI);
         const pis_hash = Poseidon.hashPacked(
-          Provable.Array(FrC.provable, 5),
+          Provable.Array(FrC.provable, CONFIG.publicInputCount),
           pis
         );
         const acc_hash = Poseidon.hashPacked(G1Affine, acc);
@@ -29,11 +32,40 @@ const zkp15 = ZkProgram({
         );
 
         let accBn = new bn254({ x: acc.x, y: acc.y });
-        accBn = accBn.add(VK.ic4.scale(pis[3]));
-        accBn = accBn.add(VK.ic5.scale(pis[4]));
-
-        accBn.x.assertCanonical().assertEquals(PI.x);
-        accBn.y.assertCanonical().assertEquals(PI.y);
+        switch (CONFIG.publicInputCount) {
+          case 0:
+          case 1:
+          case 2:
+          case 3:
+            // zkp15 handles no inputs - validate acc equals PI directly
+            accBn.x.assertCanonical().assertEquals(PI.x);
+            accBn.y.assertCanonical().assertEquals(PI.y);
+            break;
+          case 4:
+            // zkp15 handles [2,3]: ic3*pis[2] + ic4*pis[3] (2+2 distribution)
+            accBn = accBn.add(VK.ic3.scale(pis[2]));
+            accBn = accBn.add(VK.ic4.scale(pis[3]));
+            accBn.x.assertCanonical().assertEquals(PI.x);
+            accBn.y.assertCanonical().assertEquals(PI.y);
+            break;
+          case 5:
+            // zkp15 handles [3,4]: ic4*pis[3] + ic5*pis[4] (3+2 distribution)
+            accBn = accBn.add(VK.ic4.scale(pis[3]));
+            accBn = accBn.add(VK.ic5.scale(pis[4]));
+            accBn.x.assertCanonical().assertEquals(PI.x);
+            accBn.y.assertCanonical().assertEquals(PI.y);
+            break;
+          case 6:
+            // zkp15 handles [3,4,5]: ic4*pis[3] + ic5*pis[4] + ic6*pis[5] (3+3 distribution)
+            accBn = accBn.add(VK.ic4.scale(pis[3]));
+            accBn = accBn.add(VK.ic5.scale(pis[4]));
+            accBn = accBn.add(VK.ic6.scale(pis[5]));
+            accBn.x.assertCanonical().assertEquals(PI.x);
+            accBn.y.assertCanonical().assertEquals(PI.y);
+            break;
+          default:
+            throw new Error(`Unsupported input count: ${CONFIG.publicInputCount}`);
+        }
 
         return { publicOutput: pis_hash };
       },

--- a/src/groth/recursion/zkp15.ts
+++ b/src/groth/recursion/zkp15.ts
@@ -1,77 +1,64 @@
 import { Field, Poseidon, Provable, ZkProgram } from 'o1js';
-import { Accumulator } from './data.js';
-import { Fp12, FrC } from '../../towers/index.js';
-import { ArrayListHasher } from '../../array_list_hasher.js';
+import { FrC } from '../../towers/index.js';
 import { VK } from '../vk_from_env.js';
 import { G1Affine } from '../../ec/index.js';
 import { bn254 } from '../../ec/g1.js';
-import { CONFIG } from '../config.js';
+import { getDistribution } from '../config.js';
 
-const zkp15 = ZkProgram({
-  name: 'zkp15',
-  publicInput: Field,
-  publicOutput: Field,
-  methods: {
-    compute: {
-      privateInputs: [G1Affine, G1Affine, Provable.Array(FrC.provable, CONFIG.publicInputCount)],
-      async method(input: Field, PI: G1Affine, acc: G1Affine, pis: Array<FrC>) {
-        // Note: pis.length is validated at compile time by Provable.Array constraint
+// Factory function to create zkp15 with correct public input array size
+export function createZkp15(inputCount: number) {
+  const distribution = getDistribution(inputCount);
+  const zkp15InputCount = distribution.zkp15.length;
 
-        const pi_hash = Poseidon.hashPacked(G1Affine, PI);
-        const pis_hash = Poseidon.hashPacked(
-          Provable.Array(FrC.provable, CONFIG.publicInputCount),
-          pis
-        );
-        const acc_hash = Poseidon.hashPacked(G1Affine, acc);
-        input.assertEquals(
-          Poseidon.hashPacked(Provable.Array(Field, 3), [
-            pi_hash,
-            pis_hash,
-            acc_hash,
-          ])
-        );
+  const zkp15 = ZkProgram({
+    name: `zkp15_${inputCount}inputs`,
+    publicInput: Field,
+    publicOutput: Field,
+    methods: {
+      compute: {
+        privateInputs: [G1Affine, G1Affine, Provable.Array(FrC.provable, zkp15InputCount), Provable.Array(FrC.provable, inputCount)],
+        async method(input: Field, PI: G1Affine, acc: G1Affine, zkp15_pis: Array<FrC>, full_pis: Array<FrC>) {
+          const pi_hash = Poseidon.hashPacked(G1Affine, PI);
+          const pis_hash = Poseidon.hashPacked(
+            Provable.Array(FrC.provable, inputCount),
+            full_pis
+          );
+          const acc_hash = Poseidon.hashPacked(G1Affine, acc);
+          input.assertEquals(
+            Poseidon.hashPacked(Provable.Array(Field, 3), [
+              pi_hash,
+              pis_hash,
+              acc_hash,
+            ])
+          );
 
-        let accBn = new bn254({ x: acc.x, y: acc.y });
-        switch (CONFIG.publicInputCount) {
-          case 0:
-          case 1:
-          case 2:
-          case 3:
-            // zkp15 handles no inputs - validate acc equals PI directly
-            accBn.x.assertCanonical().assertEquals(PI.x);
-            accBn.y.assertCanonical().assertEquals(PI.y);
-            break;
-          case 4:
-            // zkp15 handles [2,3]: ic3*pis[2] + ic4*pis[3] (2+2 distribution)
-            accBn = accBn.add(VK.ic3.scale(pis[2]));
-            accBn = accBn.add(VK.ic4.scale(pis[3]));
-            accBn.x.assertCanonical().assertEquals(PI.x);
-            accBn.y.assertCanonical().assertEquals(PI.y);
-            break;
-          case 5:
-            // zkp15 handles [3,4]: ic4*pis[3] + ic5*pis[4] (3+2 distribution)
-            accBn = accBn.add(VK.ic4.scale(pis[3]));
-            accBn = accBn.add(VK.ic5.scale(pis[4]));
-            accBn.x.assertCanonical().assertEquals(PI.x);
-            accBn.y.assertCanonical().assertEquals(PI.y);
-            break;
-          case 6:
-            // zkp15 handles [3,4,5]: ic4*pis[3] + ic5*pis[4] + ic6*pis[5] (3+3 distribution)
-            accBn = accBn.add(VK.ic4.scale(pis[3]));
-            accBn = accBn.add(VK.ic5.scale(pis[4]));
-            accBn = accBn.add(VK.ic6.scale(pis[5]));
-            accBn.x.assertCanonical().assertEquals(PI.x);
-            accBn.y.assertCanonical().assertEquals(PI.y);
-            break;
-          default:
-            throw new Error(`Unsupported input count: ${CONFIG.publicInputCount}`);
-        }
+          let accBn = new bn254({ x: acc.x, y: acc.y });
 
-        return { publicOutput: pis_hash };
+          // Handle inputs based on distribution strategy
+          for (let i = 0; i < zkp15InputCount; i++) {
+            const originalIndex = distribution.zkp15[i]; // original index in pis array
+            const icIndex = originalIndex + 1; // ic1, ic2, etc.
+            const icPoint = VK.getIcPoint(icIndex);
+            if (!icPoint) {
+              throw new Error(`Missing IC point ic${icIndex} for zkp15 input ${i}`);
+            }
+            accBn = accBn.add(icPoint.scale(zkp15_pis[i])); // Use local index i for the zkp15 subset
+          }
+
+          // Verify that the accumulated result equals PI
+          accBn.x.assertCanonical().assertEquals(PI.x);
+          accBn.y.assertCanonical().assertEquals(PI.y);
+
+
+          return { publicOutput: pis_hash };
+        },
       },
     },
-  },
-});
+  });
 
-const ZKP15Proof = ZkProgram.Proof(zkp15);
+  return { zkp15, ZKP15Proof: ZkProgram.Proof(zkp15) };
+}
+
+// Default export for backwards compatibility (can be removed later)
+const { zkp15, ZKP15Proof } = createZkp15(5); // Default to 5 inputs for Risc0
 export { ZKP15Proof, zkp15 };

--- a/src/groth/serialize_mlo.ts
+++ b/src/groth/serialize_mlo.ts
@@ -1,11 +1,11 @@
-import { Proof } from './proof.js';
+import { parseProof } from './proof.js';
 import { Groth16Verifier } from './verifier.js';
 import fs from 'fs';
 
 // args = [vk_path, proof_path, mlo_write_path]
 
 const groth16 = new Groth16Verifier(process.argv[2]);
-const proof = Proof.parse(groth16.vk, process.argv[3]);
+const proof = parseProof(groth16.vk, process.argv[3]);
 const mlo = groth16.multiMillerLoop(proof);
 
 fs.writeFileSync(process.argv[4], mlo.toJSON(), 'utf-8');

--- a/src/groth/verifier.ts
+++ b/src/groth/verifier.ts
@@ -1,9 +1,8 @@
 import { Field, Provable } from 'o1js';
-import { G2Line } from '../lines/index.js';
 import { ATE_LOOP_COUNT, Fp12 } from '../towers/index.js';
 import { LineAccumulator } from './accumulate_lines.js';
 import { GrothVk } from './vk.js';
-import { Proof } from './proof.js';
+import { ProofData } from './proof.js';
 import { AuXWitness } from '../aux_witness.js';
 
 class Groth16Verifier {
@@ -13,7 +12,7 @@ class Groth16Verifier {
     this.vk = GrothVk.parse(path_to_vk);
   }
 
-  multiMillerLoop(proof: Proof) {
+  multiMillerLoop(proof: ProofData) {
     let g = LineAccumulator.accumulate(
       proof.b_lines,
       this.vk.gamma_lines,
@@ -38,7 +37,7 @@ class Groth16Verifier {
     return mlo;
   }
 
-  verify(proof: Proof, aux_witness: AuXWitness) {
+  verify(proof: ProofData, aux_witness: AuXWitness) {
     let g = LineAccumulator.accumulate(
       proof.b_lines,
       this.vk.gamma_lines,

--- a/src/groth/vk.ts
+++ b/src/groth/vk.ts
@@ -5,8 +5,10 @@ import { Fp12, Fp2, FpC } from '../towers/index.js';
 import fs from 'fs';
 import { bn254 } from '../ec/g1.js';
 import { ForeignCurve } from 'o1js';
+import { CONFIG } from './config.js';
 
-type SerializedVk = {
+// Base VK structure (common fields)
+type SerializedVkBase = {
   delta: {
     x_c0: string;
     x_c1: string;
@@ -21,32 +23,20 @@ type SerializedVk = {
   };
   alpha_beta: Fp12Type;
   w27: Fp12Type;
+};
 
-  // points for PI
-  ic0: {
-    x: string;
-    y: string;
-  };
-  ic1: {
-    x: string;
-    y: string;
-  };
-  ic2: {
-    x: string;
-    y: string;
-  };
-  ic3: {
-    x: string;
-    y: string;
-  };
-  ic4: {
-    x: string;
-    y: string;
-  };
-  ic5: {
-    x: string;
-    y: string;
-  };
+// Generate IC point type based on input count
+type ICPointType = { x: string; y: string };
+
+// Flexible SerializedVk type supporting all possible IC points
+type SerializedVk = SerializedVkBase & {
+  ic0: ICPointType; // Always present (base case)
+  ic1?: ICPointType;
+  ic2?: ICPointType;
+  ic3?: ICPointType;
+  ic4?: ICPointType;
+  ic5?: ICPointType;
+  ic6?: ICPointType;
 };
 
 class GrothVk {
@@ -55,41 +45,50 @@ class GrothVk {
   alpha_beta: Fp12;
   w27: Fp12;
   w27_square: Fp12;
-  ic0: ForeignCurve;
-  ic1: ForeignCurve;
-  ic2: ForeignCurve;
-  ic3: ForeignCurve;
-  ic4: ForeignCurve;
-  ic5: ForeignCurve;
+
+  // IC points stored as array for flexibility, with named accessors
+  private icPoints: ForeignCurve[];
+
+  // Named accessors for compatibility with existing code
+  get ic0() { return this.icPoints[0]; }
+  get ic1() { return this.icPoints[1]; }
+  get ic2() { return this.icPoints[2]; }
+  get ic3() { return this.icPoints[3]; }
+  get ic4() { return this.icPoints[4]; }
+  get ic5() { return this.icPoints[5]; }
+  get ic6() { return this.icPoints[6]; }
 
   constructor(
     alpha_beta: Fp12,
     w27: Fp12,
     delta: G2Affine,
     gamma: G2Affine,
-    ic0: ForeignCurve,
-    ic1: ForeignCurve,
-    ic2: ForeignCurve,
-    ic3: ForeignCurve,
-    ic4: ForeignCurve,
-    ic5: ForeignCurve
+    icPoints: ForeignCurve[]
   ) {
     this.delta_lines = computeLineCoeffs(delta);
     this.gamma_lines = computeLineCoeffs(gamma);
     this.alpha_beta = alpha_beta;
     this.w27 = w27;
     this.w27_square = w27.mul(w27);
-    this.ic0 = ic0;
-    this.ic1 = ic1;
-    this.ic2 = ic2;
-    this.ic3 = ic3;
-    this.ic4 = ic4;
-    this.ic5 = ic5;
+    this.icPoints = icPoints;
+
+    // Validate we have the expected number of IC points
+    const expectedCount = CONFIG.publicInputCount + 1; // +1 for ic0
+    if (this.icPoints.length !== expectedCount) {
+      throw new Error(`Expected ${expectedCount} IC points for ${CONFIG.publicInputCount} public inputs, got ${this.icPoints.length}`);
+    }
   }
 
   static parse(path: string): GrothVk {
     const data = fs.readFileSync(path, 'utf-8');
     const obj: SerializedVk = JSON.parse(data);
+
+    // Validate expected IC points are present  
+    for (const field of CONFIG.icFields) {
+      if (!(field in obj)) {
+        throw new Error(`Missing required IC point: ${field}`);
+      }
+    }
 
     const dx = new Fp2({
       c0: FpC.from(obj.delta.x_c0),
@@ -114,24 +113,24 @@ class GrothVk {
     const alpha_beta = Fp12.loadFromJSON(obj.alpha_beta);
     const w27 = Fp12.loadFromJSON(obj.w27);
 
-    const ic0 = new bn254({ x: FpC.from(obj.ic0.x), y: FpC.from(obj.ic0.y) });
-    const ic1 = new bn254({ x: FpC.from(obj.ic1.x), y: FpC.from(obj.ic1.y) });
-    const ic2 = new bn254({ x: FpC.from(obj.ic2.x), y: FpC.from(obj.ic2.y) });
-    const ic3 = new bn254({ x: FpC.from(obj.ic3.x), y: FpC.from(obj.ic3.y) });
-    const ic4 = new bn254({ x: FpC.from(obj.ic4.x), y: FpC.from(obj.ic4.y) });
-    const ic5 = new bn254({ x: FpC.from(obj.ic5.x), y: FpC.from(obj.ic5.y) });
+    // Parse IC points dynamically based on configuration
+    const icPoints = CONFIG.icFields.map(field => {
+      const icData = (obj as any)[field];
+      if (!icData) {
+        throw new Error(`Missing IC point data for field: ${field}`);
+      }
+      return new bn254({
+        x: FpC.from(icData.x),
+        y: FpC.from(icData.y)
+      });
+    });
 
     return new GrothVk(
       alpha_beta,
       w27,
       delta,
       gamma,
-      ic0,
-      ic1,
-      ic2,
-      ic3,
-      ic4,
-      ic5
+      icPoints
     );
   }
 }


### PR DESCRIPTION
## Description
This PR implements dynamic sizing for Groth16 proof verification, enabling support for circuits with 0-6 public inputs instead of being limited to the default 5 public inputs used by Risc0. The support is limited to 6 public inputs because Groth16 proof verification is distributed across 16 o1js circuits, and each additional public input requires expensive foreign curve scalar operations that significantly increase constraint overhead.

## Changes
The existing Groth16 implementation was hardcoded to support exactly 5 public inputs, preventing proof conversion for Circom/snarkjs and other kind of Groth16 circuits with different input configurations.

This implementation automatically detects the number of public inputs from the proof structure and dynamically instantiates the corresponding verification logic. Distribution strategies for zkp14 and zkp15 circuits, which handle public input verification, have been empirically optimized for each input count (0-6) to maximize proof generation and verification efficiency.

- `pairing-utils/src/bin/convert_from_snarkjs.rs`: Updated the script to handle arbitrary amount of public inputs
    -  https://github.com/Nori-zk/proof-conversion/pull/8
- `src/groth/proof.ts`: Refactored to auto-detect input count from proof JSON and create dynamically-sized proof classes with caching
- `src/groth/config.ts`: Added distribution strategies of 0-6 inputs to zkp14 and zkp15 (the circuits that handle public input verification)
- `src/groth/compute_pi.ts`: Updated Groth16 public input computation to handle variable array sizes using generalized formula
- `src/groth/recursion/zkp14.ts`: Converted to factory function with dynamic array sizing and distribution-aware computation
- `src/groth/recursion/zkp15.ts`: Converted to factory function in the same way with zkp14
- `src/groth/recursion/prove_zkps.ts`: Implemented distribution-aware proof orchestration with runtime configuration and fixed zkp14/zkp15 input passing
- `src/groth/verifier.ts`: Updated to accept dynamic ProofData interface instead of fixed Proof class
- `src/groth/witness_tracker.ts`: Enhanced with distribution-aware computation using `getDistribution()` function
- `src/groth/vk.ts`: Restructured for flexible IC point storage with array-based access and dynamic parsing
- `src/groth/serialize_mlo.ts`: Updated to use new `parseProof()` function
- src/groth/e2e_test.ts: Updated to use new `parseProof()` function

## Examples
Here's the branch demonstrates the complete implementation with example Circom/snarkjs circuits for all supported input counts (0-6):
https://github.com/0x471/proof-conversion/tree/groth16-configurable-inputs-examples/groth16-input-tests

## Limitations
- Maximum of 6 public inputs due to current zkProgram constraints
- Each additional public input increases computational overhead due to foreign curve operations
- Expanding beyond 6 inputs would require architectural changes to the  zkProgram recursion distribution

## Checks
- [x] `src/groth/e2e_test.ts` works 
- [x] `scripts/risc_zero_example/e2e_risc_zero.sh` works 
- [x] `scripts/e2e_groth16.sh` works 
- [x] `groth16-input-tests/run_all_circuits.sh` in my personal branch mentioned above works 