### PR TITLE
Build request 13/2/26

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,7 +407,7 @@ interface ConversionOutput {
 
 ### Minimal export
 
-The package exports via the `/min` path, useful types and some limited utilities omitting anything which relies on a Node.js dependancy. This is largely to support frontend applications. **Note** none of the proof conversion "plans" e.g. `performSp1Plonk` nor the `ComputationalPlanExecutor` are exported.
+The package exports via the `/min` path, useful types and some limited utilities omitting anything which relies on a Node.js dependancy. This is largely to support frontend applications. **Note** none of the proof conversion "plans" e.g. `performSp1Plonk`, the `ComputationalPlanExecutor` nor the wasm based utilities are exported.
 
 ```typescript
 import {
@@ -415,11 +415,7 @@ import {
   wordToBytes,
   NodeProofLeft,
   FrC,
-  DeferredPromise,
-  computeAuxWitness,
-  convertSp1Groth16ToO1js,
-  convertSnarkjsGroth16ToO1js,
-  computeRisc0Groth16Pairing,
+  DeferredPromise
 } from '@nori-zk/proof-conversion/min'; // These utilities are also available in '@nori-zk/proof-conversion'
 
 import type {
@@ -435,6 +431,19 @@ import type {
   SP1ProofWithPublicValuesGroth16NoTee,
   SP1ProofWithPublicValuesPlonkNoTee,
 } from '@nori-zk/proof-conversion/min'; // These types are also available in '@nori-zk/proof-conversion'
+```
+
+### Wasm utilities
+
+The package exports via the `/wasm-utils` path, useful wasm based utilities are included to assist proof conversions from one format to another - omitting anything which relies on a Node.js dependancy. 
+
+```typescript
+import {
+  computeAuxWitness,
+  convertSp1Groth16ToO1js,
+  convertSnarkjsGroth16ToO1js,
+  computeRisc0Groth16Pairing,
+} from '@nori-zk/proof-conversion/wasm-utils'; // These types are also available in '@nori-zk/proof-conversion'
 ```
 
 ### Validation utilities

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nori-zk/proof-conversion",
-  "version": "0.8.15",
+  "version": "0.8.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nori-zk/proof-conversion",
-      "version": "0.8.15",
+      "version": "0.8.16",
       "license": "Apache-2.0",
       "dependencies": {
         "@nori-zk/proof-conversion-utils": "0.5.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nori-zk/proof-conversion",
-  "version": "0.8.15",
+  "version": "0.8.16",
   "description": "Verifying zkVM proofs inside o1js circuits, to generate Mina compatible proof",
   "author": "",
   "license": "Apache-2.0",
@@ -23,6 +23,9 @@
     },
     "./min": {
       "import": "./build/src/index.min.js"
+    },
+    "./wasm-utils": {
+      "import": "./build/src/index.wasm_utils.js"
     },
     "./validation": {
       "import": "./build/src/api/validation/index.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nori-zk/proof-conversion",
-  "version": "0.8.15",
+  "version": "0.8.16",
   "description": "Verifying zkVM proofs inside o1js circuits, to generate Mina compatible proof",
   "author": "",
   "license": "Apache-2.0",

--- a/src/index.min.ts
+++ b/src/index.min.ts
@@ -9,10 +9,10 @@ export type * from './compute/types.js';
 export type * from './api/risc0/schema.js';
 export type * from './api/snarkjs/schema.js';
 export type * from './api/sp1/schema.js';
+export type * from '@nori-zk/proof-conversion-utils';
 
 // Utilities
 
-export * from '@nori-zk/proof-conversion-utils';
 export { parsePublicInputsProvable as parsePlonkPublicInputsProvable } from './plonk/parse_pi.js';
 export { wordToBytes } from './sha/utils.js';
 export { NodeProofLeft } from './structs.js';

--- a/src/index.wasm_utils.ts
+++ b/src/index.wasm_utils.ts
@@ -1,0 +1,2 @@
+// Wasm functions
+export * from '@nori-zk/proof-conversion-utils';


### PR DESCRIPTION
Extracting out wasm based proof conversion utilities to their own path as they were causing frontend bundling issues and we only need them for their types in most situations.