### PR TITLE
FIX: audit b165f, explicit range constraint on shift_power at all 6 P…

### DIFF
--- a/src/groth/recursion/zkp13.ts
+++ b/src/groth/recursion/zkp13.ts
@@ -36,6 +36,12 @@ const zkp13 = ZkProgram({
           .mul(acc.proof.c_inv.frobenius_pow_p_cubed())
           .mul(VK.alpha_beta);
 
+        // Assert acc.proof.shift_power is constrained to {0, 1, 2}
+        acc.proof.shift_power
+          .mul(acc.proof.shift_power.sub(1))
+          .mul(acc.proof.shift_power.sub(2))
+          .assertEquals(0, 'acc.proof.shift_power is not in the set {0, 1, 2}');
+          
         const shift = Provable.switch(
           [
             acc.proof.shift_power.equals(Field(0)),

--- a/src/groth/verifier.ts
+++ b/src/groth/verifier.ts
@@ -75,6 +75,12 @@ class Groth16Verifier {
       .mul(c.frobenius_pow_p_squared())
       .mul(c_inv.frobenius_pow_p_cubed())
       .mul(this.vk.alpha_beta);
+    
+    // Assert shift_power is constrained to {0, 1, 2}
+    shift_power
+      .mul(shift_power.sub(1))
+      .mul(shift_power.sub(2))
+      .assertEquals(0, 'shift_power is not in the set {0, 1, 2}');
 
     const shift = Provable.switch(
       [

--- a/src/groth/witness_tracker.ts
+++ b/src/groth/witness_tracker.ts
@@ -310,6 +310,12 @@ class WitnessTracker {
     const w27 = VK.w27;
     const w27_sq = VK.w27_square;
 
+    // Assert acc.proof.shift_power is constrained to {0, 1, 2}
+    this.acc.proof.shift_power
+      .mul(this.acc.proof.shift_power.sub(1))
+      .mul(this.acc.proof.shift_power.sub(2))
+      .assertEquals(0, 'acc.proof.shift_power is not in the set {0, 1, 2}');
+
     const shift = Provable.switch(
       [
         this.acc.proof.shift_power.equals(Field(0)),

--- a/src/plonk/mm_loop/multi_miller.ts
+++ b/src/plonk/mm_loop/multi_miller.ts
@@ -76,6 +76,12 @@ class KZGPairing {
       .mul(c.frobenius_pow_p_squared())
       .mul(c_inv.frobenius_pow_p_cubed());
 
+    // Assert shift_power is constrained to {0, 1, 2}
+    shift_power
+      .mul(shift_power.sub(1))
+      .mul(shift_power.sub(2))
+      .assertEquals(0, 'shift_power is not in the set {0, 1, 2}');
+
     const shift = Provable.switch(
       [
         shift_power.equals(Field(0)),

--- a/src/plonk/recursion/witness_tracker.ts
+++ b/src/plonk/recursion/witness_tracker.ts
@@ -512,6 +512,12 @@ class WitnessTracker {
     const w27 = make_w27();
     const w27_sq = w27.square();
 
+    // Assert kzg.proof.shift_power is constrained to {0, 1, 2}
+    this.kzg.proof.shift_power
+      .mul(this.kzg.proof.shift_power.sub(1))
+      .mul(this.kzg.proof.shift_power.sub(2))
+      .assertEquals(0, 'kzg.proof.shift_power is not in the set {0, 1, 2}');
+
     const shift = Provable.switch(
       [
         this.kzg.proof.shift_power.equals(Field(0)),

--- a/src/plonk/recursion/zkp23.ts
+++ b/src/plonk/recursion/zkp23.ts
@@ -38,6 +38,12 @@ const zkp23 = ZkProgram({
           .mul(acc.proof.c.frobenius_pow_p_squared())
           .mul(acc.proof.c_inv.frobenius_pow_p_cubed());
 
+        // Assert acc.proof.shift_power is constrained to {0, 1, 2}
+        acc.proof.shift_power
+          .mul(acc.proof.shift_power.sub(1))
+          .mul(acc.proof.shift_power.sub(2))
+          .assertEquals(0, 'acc.proof.shift_power is not in the set {0, 1, 2}');
+
         const shift = Provable.switch(
           [
             acc.proof.shift_power.equals(Field(0)),


### PR DESCRIPTION
…rovable.switch call sites (3 groth16, 3 plonk), enforcing shift_power in {0, 1, 2} via polynomial constraint (3 gates per site). Previously only implicitly rejected via Provable.switch returning Fp12.zero() on all-false mask, an undocumented o1js implementation detail, not an API contract

Commit 1: df976e4612f31e97d3f03dfb18d94fa79435aead