### PR TITLE
Fix/audit ec50d: Groth recursion verifier is missing on-curve and subgroup checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,238 @@
+# 26/5/26 - Audit EC50D: Missing on-curve and subgroup checks in Groth16 and PLONK recursion verifiers
+
+## Finding (verbatim)
+
+Finding ec50d: Groth recursion verifier is missing on-curve and subgroup checks
+
+The 16-segments zkp that verifies the groth16 proof does not validate that the proof points are on curve, and, for the G2 points, in the relevant subgroup.
+
+I have attached a more detailed description including an explanation how I verified that there are no (explicit or implicit) on-curve checks for the negA -point (others are analogous) and how this can be exploited
+
+### Missing on-curve and subgroup checks in the Groth16 recursion verifier
+
+The Groth16 verifier circuit (the sequence of recursion proofs `zkp0`, ..., `zkp15` under `src/groth/recursion/`) operates over two groups on the BN254 curve:
+
+- G1 is the full group E(Fp), which for BN254 has prime order r. On-curve membership is therefore equivalent to subgroup membership: a single on-curve check is sufficient.
+- G2 is the order-r subgroup of E'(Fp2) (the sextic twist of the original curve used by the BN254 pairing). The full group E'(Fp2) has cofactor much larger than 1, so on-curve membership does not imply order-r membership. Both an on-curve check and a subgroup-membership check are therefore required.
+
+The verifier consumes three prover-controlled proof points: `negA` and `C` on G1, and `B` on G2. These enter the verifier via `parseProof` in `src/groth/proof.ts`:
+
+```ts
+// proof-conversion/src/groth/proof.ts
+const negA = new G1Affine({
+  x: FpC.from(json.negA.x),
+  y: FpC.from(json.negA.y),
+});
+
+const C = new G1Affine({
+  x: FpC.from(json.C.x),
+  y: FpC.from(json.C.y),
+});
+
+const B = new G2Affine({
+  x: new Fp2({ c0: FpC.from(json.B.x_c0), c1: FpC.from(json.B.x_c1) }),
+  y: new Fp2({ c0: FpC.from(json.B.y_c0), c1: FpC.from(json.B.y_c1) }),
+});
+```
+
+The `G1Affine` and `G2Affine` types are plain `Struct`s over the field coordinates, with no curve relation enforced:
+
+```ts
+// proof-conversion/src/ec/index.ts
+class G1Affine extends Struct({ x: FpA.provable, y: FpA.provable }) {}
+
+// proof-conversion/src/ec/g2.ts
+class G2Affine extends Struct({ x: Fp2, y: Fp2 }) {}
+```
+
+The only constraint applied to the parsed coordinates is canonicality (`< p`). The curve equation `y^2 = x^3 + 3` (for `negA`, `C`) and its Fp2 twist analogue (for `B`) are never asserted, and no order-r subgroup-membership test is performed on `B`. The missing checks are therefore: on-curve for `negA` and `C`, and both on-curve and subgroup-membership for `B`.
+
+These checks are also not enforced indirectly anywhere else in the verifier. The pre-pairing constraints `b_line.assert_is_tangent` / `b_line.assert_is_line` (`src/lines/index.ts:106,119`) enforce only line identities (y - lambda*x + neg_mu = 0 and 2*lambda*y = 3x^2), which hold for any pair (x, y) whose coordinates were used to derive lambda and neg_mu off-circuit via the same formulas, regardless of whether (x, y) lies on the curve. Inside the per-stage circuits, the proof points flow through `AffineCache` (`src/lines/precompute.ts`), which requires only that the point's y coordinate be non-zero (via `yp_prime * y = 1`). Across `zkp0`, ..., `zkp12`, every constraint on the proof points can be satisfied for any off-curve pair of canonical field elements. The only remaining assertion is the final pairing equality `f.assert_equals(Fp12.one())` at `src/groth/recursion/zkp13.ts:50` (mirrored off-circuit at `src/groth/witness_tracker.ts:323`) -- a check on the pairing relation, not on curve or subgroup membership of the inputs.
+
+To confirm the absence of these checks end-to-end, we constructed a PoC that (a) tampers `negA.y` to `(negA.y + 1) mod p` before the proof is parsed and (b) gates out the final pairing equality `f.assert_equals(Fp12.one())` (both the in-circuit assertion at `zkp13.ts:50` and the off-circuit sanity check at `witness_tracker.ts:323`), then runs the full recursion pipeline `zkp0`, ..., `zkp15` against the example fixtures at `src/groth/example_jsons/`. The full patch is:
+
+```diff
+--- a/src/groth/recursion/prove_zkps.ts
++++ b/src/groth/recursion/prove_zkps.ts
+@@ -28,7 +28,43 @@ import { VK } from '../vk_from_env.js';
+
+ const args = process.argv;
+
+-const proof = parseProof(VK, args[3]);
++// POC_OFFCURVE_NEGA: when set, rewrite the proof JSON to use an off-curve negA
++// (y' = y + 1 mod p). This demonstrates that no on-curve check rejects the
++// point through any of the pre-final checks. The 'final' pairing assertion
++// (zkp13 + witness_tracker.zkp13) must be disabled separately for the demo.
++const BN254_P =
++  21888242871839275222246405745257275088696311157297823662689037894645226208583n;
++let proofPathForParse = args[3];
++if (process.env.POC_OFFCURVE_NEGA === '1') {
++  const origJson = JSON.parse(fs.readFileSync(args[3], 'utf-8'));
++  const xBig = BigInt(origJson.negA.x);
++  const yBig = BigInt(origJson.negA.y);
++  let yNewBig = (yBig + 1n) % BN254_P;
++  if (yNewBig === 0n) yNewBig = (yBig + 2n) % BN254_P;
++  const lhs = (yNewBig * yNewBig) % BN254_P;
++  const rhs = (((xBig * xBig) % BN254_P) * xBig + 3n) % BN254_P;
++  const onCurve = lhs === rhs;
++  console.log('[POC_OFFCURVE_NEGA] original negA.y =', yBig.toString());
++  console.log('[POC_OFFCURVE_NEGA] tampered negA.y =', yNewBig.toString());
++  console.log(
++    '[POC_OFFCURVE_NEGA] does tampered (x,y) satisfy y^2 = x^3 + 3 (mod p)?',
++    onCurve
++  );
++  if (onCurve) {
++    throw new Error(
++      'POC sanity check: tampered point is still on the curve; pick a different offset'
++    );
++  }
++  origJson.negA.y = yNewBig.toString();
++  proofPathForParse = `${args[3]}.poc_offcurve.json`;
++  fs.writeFileSync(proofPathForParse, JSON.stringify(origJson), 'utf-8');
++  console.log(
++    '[POC_OFFCURVE_NEGA] wrote tampered proof JSON to',
++    proofPathForParse
++  );
++}
++
++const proof = parseProof(VK, proofPathForParse);
+ const auxWitness = AuXWitness.parse(args[4]);
+ const workDir = args[5];
+ const cacheDir = args[6];
+--- a/src/groth/recursion/zkp13.ts
++++ b/src/groth/recursion/zkp13.ts
+@@ -47,7 +47,11 @@ const zkp13 = ZkProgram({
+         );
+         f = f.mul(shift);
+
+-        f.assert_equals(Fp12.one());
++        // POC_OFFCURVE_NEGA: skip the final pairing assertion when the PoC
++        // env flag is set, since a generic off-curve negA makes f != 1
++        if (process.env.POC_OFFCURVE_NEGA !== '1') {
++          f.assert_equals(Fp12.one());
++        }
+
+         acc.state.f = f;
+
+--- a/src/groth/witness_tracker.ts
++++ b/src/groth/witness_tracker.ts
+@@ -320,7 +320,11 @@ class WitnessTracker {
+       [Fp12.one(), w27, w27_sq]
+     );
+     f = f.mul(shift);
+-    f.assert_equals(Fp12.one());
++    // POC_OFFCURVE_NEGA: skip the off-circuit pairing sanity check when the
++    // PoC env flag is set, since a generic off-curve negA makes f != 1
++    if (process.env.POC_OFFCURVE_NEGA !== '1') {
++      f.assert_equals(Fp12.one());
++    }
+
+     this.acc.state.f = f;
+     return this.acc.deepClone();
+```
+
+Running the pipeline with `POC_OFFCURVE_NEGA=1`, every stage produces a valid proof:
+
+```
+[POC_OFFCURVE_NEGA] does tampered (x,y) satisfy y^2 = x^3 + 3 (mod p)? false
+valid zkp0?:  true
+valid zkp1?:  true
+valid zkp2?:  true
+valid zkp3?:  true
+valid zkp4?:  true
+valid zkp5?:  true
+valid zkp6?:  true
+valid zkp7?:  true
+valid zkp8?:  true
+valid zkp9?:  true
+valid zkp10?:  true
+valid zkp11?:  true
+valid zkp12?:  true
+valid zkp13?:  true
+valid zkp14?:  true
+valid zkp15?:  true
+```
+
+The same PoC structure straightforwardly extends to tampering `C` and `B`. For `B`, the `b_lines` (line coefficients) are computed off-circuit in `parseProof` via `computeLineCoeffs(B)` (`src/lines/coeffs.ts`); recomputing them from the tampered `B` keeps the line constraints `assert_is_tangent` / `assert_is_line` satisfied throughout the Miller loop, by construction.
+
+#### Impact
+
+The Groth16 verifier is the trust anchor for one of the two SNARK families consumed by the Nori bridge (the other being PLONK; see `src/plonk/`). For example, the SP1 Groth16 path produces a final Mina proof whose `rightOut` field is consumed by `NoriTokenBridge.ethVerify` on the Mina side to authorize state-root and deposit-root updates. A break of the Groth16 verifier therefore allows an attacker to forge arbitrary public values into the bridge's accepted state, with the same end-state consequences as documented in finding b1114.
+
+The missing on-curve / subgroup checks weaken the verifier's soundness in the following ways:
+
+- Pairing-equation soundness depends on `B` being in G2, not just on `B` being on the twisted curve. The Groth16 pairing identity is a statement about the order-r bilinear pairing; off-subgroup inputs do not produce a meaningful equality, and the soundness argument fails. The Miller loop the circuit computes is designed so that its output equals 1 exactly when the pairing identity holds on inputs from G2; for a `B` on the twisted curve but outside G2, the same Miller loop evaluates to a different multi-curve relation, and the final `f.assert_equals(Fp12.one())` no longer carries the intended meaning. This is practically exploitable: the cofactor of G2 in the twisted curve has small prime factors, so points of small order outside G2 are easy to construct and combine with a valid `B` to drive the Miller-loop output into a regime where the final equality can be satisfied without honoring the pairing identity.
+- Off-curve inputs produce values in the larger group E'(Fp2) (or even outside it). All of the verifier's per-stage constraints -- tangent/secant line identities, Frobenius identities, the residue-witness consistency relations -- are formal polynomial relations that hold over the full coordinate field, not over the curve. The single remaining soundness barrier is therefore the final pairing equality `f.assert_equals(Fp12.one())`. Whether a malicious prover can satisfy that final equality with a forged residue witness on off-curve or off-subgroup inputs is a question entirely about the residue-witness construction; nothing in the circuit forces them to play on the intended group.
+
+#### Recommendations
+
+Add explicit on-curve and (for `B`) subgroup-membership constraints to the proof inputs of the Groth16 verifier circuit, applied inside the ZkProgram of `zkp0` (or wherever each point is first used in-circuit) so that the constraint becomes part of the verifier's constraint system rather than an off-circuit sanity check.
+
+Concretely:
+
+- `negA` and `C` (in G1): add an in-circuit assertion that the point satisfies the BN254 curve equation. Since G1 has prime order, an on-curve check alone is sufficient. The o1js `ForeignCurve` class already provides an `assertOnCurve()` method, so the simplest implementation is to either reroute `G1Affine` through the existing `bn254` curve type in `src/ec/g1.ts`, or to add an equivalent assertion directly on the `G1Affine` coordinates.
+- `B` (in G2): add both an on-curve check (the curve equation of the twisted curve, using the twist parameters already in `src/towers/precomputed.ts`) and a subgroup-membership check. The standard efficient construction is the Frobenius-based subgroup test of Dai et al., which decides membership using only the Frobenius endomorphism and a small number of point operations; the Frobenius primitive itself is already implemented as `G2Affine.frobenius()` and `G2Affine.negative_frobenius()` in `src/ec/g2.ts`. Implementing this check requires non-trivial circuit logic but does not require any new primitives.
+
+## Response
+
+We agree with the auditor's findings that all three Groth16 prover-supplied proof points (negA, C on G1; B on G2) enter the recursion circuit as raw field coordinates with no curve equation or subgroup membership enforced in-circuit. After discussion with the o1js-blobstream author, we extended the scope to include the PLONK path, which has the same class of vulnerability on its 10 prover-supplied G1 points.
+
+## Discussion
+
+The o1js-blobstream author provided a four-step framework for G2 subgroup checking that leverages the existing Miller loop:
+
+> During the BN254 optimal-ate Miller loop, we are not only accumulating the F_{p^{12}} Miller value; we also have a curve-point accumulator (T). The main loop computes the short scalar part, roughly [6u+2]Q, and then the final correction steps add/subtract Frobenius images of Q. So at the end, T is checking an endomorphism relation of the form
+>
+> [6u+2]Q + pi(Q) - pi^2(Q) + pi^3(Q) = O
+>
+> up to the exact sign/convention used by the implementation.
+>
+> On G_2[r], Frobenius acts like scalar multiplication by the corresponding Frobenius eigenvalue, so this endomorphism relation is zero modulo r. Therefore, for a valid r-torsion point, the final point accumulator should end at infinity.
+>
+> So for an untrusted G_2 proof element, the subgroup-check logic can be:
+>
+> 1. check the point is on the correct twist curve,
+> 2. check it is not infinity,
+> 3. run the Miller loop including the Frobenius correction steps,
+> 4. check that the final curve-point accumulator (T) is infinity.
+>
+> This serves the same purpose as checking [r]Q = O, but it is cheaper because the large scalar contribution is represented using Frobenius maps and it's already implicit inside the miller loop that we anyway do.
+
+Our read on these four points:
+
+1. Check the point is on the correct twist curve.
+   - Not done. B is prover-supplied, need y^2 = x^3 + b_twist asserted in-circuit. 209 rows, zkp6 is at 47,322 (fits).
+
+2. Check it is not infinity.
+   - Not needed. Affine coordinates cannot encode infinity, therefore neither can a malicious actor.
+
+3. Run the Miller loop including the Frobenius correction steps.
+   - Already done. zkp0-zkp6, T tracked alongside f, Frobenius corrections applied at end of zkp6.
+
+4. Check that the final curve-point accumulator (T) is infinity.
+   - Not done but not hard. T and the Frobenius corrections already exist in zkp6, the code just discards T without checking it. The last operation is assert_is_line(T, pi_2_B) with no subsequent addition. Fix is to advance T past pi_2_B, compute pi_3_B = frobenius(pi^2(B)), and assert T = -pi_3_B (same x, negated y).
+
+None of this is needed for PLONK as the G2 points (g2, tau) are hardcoded VK constants precomputed into JSON at build time.
+
+For G1, BN254 G1 has prime order r, so on-curve implies subgroup membership. One assertOnCurve() call per point (125 rows each via bn254 createForeignCurve) is sufficient. This applies to both the Groth16 path (negA, C, PI) and the PLONK path (l_com, r_com, o_com, qcp_0_wire, grand_product, h0, h1, h2, batch_opening_at_zeta, batch_opening_at_zeta_omega).
+
+### Commit 1 - Regression tests exposing missing on-curve and subgroup checks
+
+- **Groth16 regression tests** (`src/groth/ec50d_regression.spec.ts`): 5 tests covering all Groth16 prover-supplied proof points. Three G1 on-curve tests parse a real proof from `src/groth/example_jsons/`, tamper the y coordinate of a single point (+1 mod p, verified off-curve), construct a WitnessTracker, and expect proof generation via the real ZkProgram to be rejected. One G2 on-curve test tampers B.y.c0 and expects zkp6 to reject. One combined G2 subgroup test exercises the endomorphism identity from steps 3-4 above: the Miller loop's T accumulator evaluates [6u+2]B + pi(B) - pi^2(B) + pi^3(B); for B in G2[r] this equals O (T reaches infinity), for B outside G2[r] it does not. The test constructs a point on E'(Fp2) outside G2[r] via Fp2 Tonelli-Shanks and expects zkp6 to reject it, then runs valid proof B through zkp6 and expects acceptance. Both assertions are in one test so it fails on every broken state: missing check (bad B accepted), wrong endomorphism relation (valid B rejected), or correct check (both pass). Tests: `zkp0 must reject off-curve negA`, `zkp0 must reject off-curve C`, `zkp0 must reject off-curve PI`, `zkp6 must reject off-curve B` (G2 on-curve check), `zkp6 subgroup check must reject bad B and accept valid B`.
+- **PLONK regression tests** (`src/plonk/ec50d_regression.spec.ts`): 10 tests covering all PLONK prover-supplied G1 points. Each test constructs a real Accumulator from a hardcoded hex proof, tampers the y coordinate of a single point (+1 mod p, verified off-curve), and expects proof generation via PLONK zkp0 to be rejected. Tests: `zkp0 must reject off-curve l_com`, `zkp0 must reject off-curve r_com`, `zkp0 must reject off-curve o_com`, `zkp0 must reject off-curve qcp_0_wire`, `zkp0 must reject off-curve grand_product`, `zkp0 must reject off-curve h0`, `zkp0 must reject off-curve h1`, `zkp0 must reject off-curve h2`, `zkp0 must reject off-curve batch_opening_at_zeta`, `zkp0 must reject off-curve batch_opening_at_zeta_omega`.
+
+Run:
+
+```
+GROTH16_VK_PATH=./src/groth/example_jsons/vk.json npm run test:jest -- src/groth/ec50d_regression.spec.ts
+npm run test:jest -- src/plonk/ec50d_regression.spec.ts
+```
+
+Results:
+
+- Groth16 regression tests: 5 fail, 0 pass. All five tests resolve instead of rejecting, confirming that zkp0 and zkp6 accept off-curve and off-subgroup proof points.
+- PLONK regression tests: 10 fail, 0 pass. All ten tests resolve instead of rejecting, confirming that PLONK zkp0 accepts off-curve proof points.
+
 # 18/5/26 - Audit B1114: Disabled layer1 subtrees unconstrained, allowing forgery of SP1 PLONK public inputs
 
 ## Finding (verbatim)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -233,6 +233,22 @@ Results:
 - Groth16 regression tests: 5 fail, 0 pass. All five tests resolve instead of rejecting, confirming that zkp0 and zkp6 accept off-curve and off-subgroup proof points.
 - PLONK regression tests: 10 fail, 0 pass. All ten tests resolve instead of rejecting, confirming that PLONK zkp0 accepts off-curve proof points.
 
+### Commit 2 - Fix applied
+
+- **`src/ec/index.ts`**: added `assertOnCurve()` method to `G1Affine`, delegates to `bn254.assertOnCurve()`.
+- **`src/towers/precomputed.ts`**: added `B_TWIST` constant (3/(9+u) in Fp2) for G2 twist curve equation.
+- **`src/groth/recursion/zkp0.ts`**: added G1 on-curve checks for negA, C, PI.
+- **`src/groth/recursion/zkp6.ts`**: added G2 on-curve check (y^2 = x^3 + b_twist) and G2 subgroup check. After the existing pi(B) and -pi^2(B) Frobenius corrections, T is advanced past pi_2_B and checked against -pi_3_B (same x, negated y), enforcing the full 4-term endomorphism relation [6u+2]B + pi(B) - pi^2(B) + pi^3(B) = O.
+- **`src/groth/witness_tracker.ts`**: added off-circuit G2 subgroup check as dev sanity mirror of the in-circuit check in zkp6.
+- **`src/plonk/recursion/zkp0.ts`**: added G1 on-curve checks for all 10 prover-supplied points.
+
+Results:
+
+- Groth16 regression tests: 5 pass, 0 fail.
+- PLONK regression tests: 10 pass, 0 fail.
+
+---
+
 # 18/5/26 - Audit B1114: Disabled layer1 subtrees unconstrained, allowing forgery of SP1 PLONK public inputs
 
 ## Finding (verbatim)

--- a/src/ec/index.ts
+++ b/src/ec/index.ts
@@ -1,7 +1,12 @@
 import { Struct } from 'o1js';
 import { FpA } from '../towers/fp.js';
 import { G2Affine } from './g2.js';
+import { bn254 } from './g1.js';
 
-class G1Affine extends Struct({ x: FpA.provable, y: FpA.provable }) {}
+class G1Affine extends Struct({ x: FpA.provable, y: FpA.provable }) {
+  assertOnCurve() {
+    new bn254({ x: this.x, y: this.y }).assertOnCurve();
+  }
+}
 
 export { G1Affine, G2Affine };

--- a/src/groth/ec50d_regression.spec.ts
+++ b/src/groth/ec50d_regression.spec.ts
@@ -1,0 +1,281 @@
+import { rmSync } from 'fs';
+import { Cache, Poseidon } from 'o1js';
+import { parseProof } from './proof.js';
+import { AuXWitness } from '../aux_witness.js';
+import { WitnessTracker } from './witness_tracker.js';
+import { Accumulator } from './recursion/data.js';
+import { G1Affine } from '../ec/index.js';
+import { G2Affine } from '../ec/g2.js';
+import { FpC, Fp2 } from '../towers/index.js';
+import { zkp0 } from './recursion/zkp0.js';
+import { zkp6 } from './recursion/zkp6.js';
+import { GrothVk } from './vk.js';
+
+const BN254_P =
+  21888242871839275222246405745257275088696311157297823662689037894645226208583n;
+
+type Fp2Tuple = [bigint, bigint];
+
+const fp_pow = (base: bigint, exp: bigint): bigint => {
+  let result = 1n;
+  base = ((base % BN254_P) + BN254_P) % BN254_P;
+  while (exp > 0n) {
+    if (exp & 1n) result = result * base % BN254_P;
+    exp >>= 1n;
+    base = base * base % BN254_P;
+  }
+  return result;
+};
+const fp_inv = (a: bigint) => fp_pow(a, BN254_P - 2n);
+
+const fp2_mul = (a: Fp2Tuple, b: Fp2Tuple): Fp2Tuple => [
+  ((a[0]*b[0] % BN254_P) - (a[1]*b[1] % BN254_P) + BN254_P) % BN254_P,
+  ((a[0]*b[1] % BN254_P) + (a[1]*b[0] % BN254_P)) % BN254_P,
+];
+const fp2_add = (a: Fp2Tuple, b: Fp2Tuple): Fp2Tuple => [
+  (a[0]+b[0]) % BN254_P, (a[1]+b[1]) % BN254_P,
+];
+const fp2_sq = (a: Fp2Tuple) => fp2_mul(a, a);
+const fp2_inv = (a: Fp2Tuple): Fp2Tuple => {
+  const norm = (a[0]*a[0] % BN254_P + a[1]*a[1] % BN254_P) % BN254_P;
+  const inv_n = fp_inv(norm);
+  return [(a[0]*inv_n) % BN254_P, ((BN254_P - a[1])*inv_n) % BN254_P];
+};
+
+const fp_sqrt = (n: bigint): bigint | null => {
+  n = ((n % BN254_P) + BN254_P) % BN254_P;
+  if (n === 0n) return 0n;
+  if (fp_pow(n, (BN254_P - 1n) / 2n) !== 1n) return null;
+  let q = BN254_P - 1n, s = 0n;
+  while (q % 2n === 0n) { q /= 2n; s++; }
+  let z = 2n;
+  while (fp_pow(z, (BN254_P - 1n) / 2n) !== BN254_P - 1n) z++;
+  let m = s, c = fp_pow(z, q), t = fp_pow(n, q), r = fp_pow(n, (q + 1n) / 2n);
+  while (true) {
+    if (t === 1n) return r;
+    let i = 1n, tmp = t * t % BN254_P;
+    while (tmp !== 1n) { tmp = tmp * tmp % BN254_P; i++; }
+    let b = c;
+    for (let j = 0n; j < m - i - 1n; j++) b = b * b % BN254_P;
+    m = i; c = b * b % BN254_P; t = t * c % BN254_P; r = r * b % BN254_P;
+  }
+};
+
+const fp2_sqrt = (a: Fp2Tuple): Fp2Tuple | null => {
+  if (a[1] === 0n) {
+    const s = fp_sqrt(a[0]);
+    if (s !== null) return [s, 0n];
+    const s2 = fp_sqrt((BN254_P - a[0]) % BN254_P);
+    if (s2 !== null) return [0n, s2];
+    return null;
+  }
+  const norm = (a[0]*a[0] % BN254_P + a[1]*a[1] % BN254_P) % BN254_P;
+  const ns = fp_sqrt(norm);
+  if (ns === null) return null;
+  let alpha = (a[0] + ns) % BN254_P;
+  alpha = alpha * fp_inv(2n) % BN254_P;
+  let delta = fp_sqrt(alpha);
+  if (delta === null) {
+    alpha = ((a[0] - ns) % BN254_P + BN254_P) % BN254_P;
+    alpha = alpha * fp_inv(2n) % BN254_P;
+    delta = fp_sqrt(alpha);
+    if (delta === null) return null;
+  }
+  const c1 = a[1] * fp_inv(2n * delta % BN254_P) % BN254_P;
+  const y: Fp2Tuple = [delta, c1];
+  const y2 = fp2_sq(y);
+  if (y2[0] === a[0] && y2[1] === a[1]) return y;
+  return null;
+};
+
+function findTwistPointNotInSubgroup(): G2Affine {
+  const b_tw = fp2_mul([3n, 0n], fp2_inv([9n, 1n]));
+  for (let i = 1n; i < 100n; i++) {
+    const x: Fp2Tuple = [i, i + 1n];
+    const rhs = fp2_add(fp2_mul(fp2_sq(x), x), b_tw);
+    const y = fp2_sqrt(rhs);
+    if (y) {
+      return new G2Affine({
+        x: new Fp2({ c0: FpC.from(x[0]), c1: FpC.from(x[1]) }),
+        y: new Fp2({ c0: FpC.from(y[0]), c1: FpC.from(y[1]) }),
+      });
+    }
+  }
+  throw new Error('failed to find twist point');
+}
+
+const VK_PATH = './src/groth/example_jsons/vk.json';
+const PROOF_PATH = './src/groth/example_jsons/proof.json';
+const AUX_PATH = './src/groth/example_jsons/aux_witness.json';
+const CACHE_DIR = './cache_ec50d_groth';
+
+process.env.GROTH16_VK_PATH = VK_PATH;
+
+const vk = GrothVk.parse(VK_PATH);
+
+describe('regression_ec50d_groth16_oncurve', () => {
+  beforeAll(async () => {
+    await zkp0.compile({ cache: Cache.FileSystem(CACHE_DIR) });
+  }, 600_000);
+
+  afterAll(() => {
+    rmSync(CACHE_DIR, { recursive: true, force: true });
+  });
+
+  test('zkp0 must reject off-curve negA (G1 on-curve check)', async () => {
+    const proof = parseProof(vk, PROOF_PATH);
+    const auxWitness = AuXWitness.parse(AUX_PATH);
+
+    const origY = proof.negA.y.toBigInt();
+    const tamperedY = (origY + 1n) % BN254_P;
+    const lhs = (tamperedY * tamperedY) % BN254_P;
+    const x = proof.negA.x.toBigInt();
+    const rhs = (((x * x) % BN254_P) * x + 3n) % BN254_P;
+    expect(lhs).not.toBe(rhs);
+
+    const tamperedProof = {
+      ...proof,
+      negA: new G1Affine({ x: proof.negA.x, y: FpC.from(tamperedY) }),
+    };
+
+    const wt = new WitnessTracker(tamperedProof, auxWitness);
+    const [acc_0, lines_0, all_b_lines] = wt.in0();
+    const cin0 = Poseidon.hashPacked(Accumulator, acc_0);
+
+    await expect(
+      zkp0.compute(cin0, acc_0, lines_0, all_b_lines)
+    ).rejects.toThrow();
+  }, 600_000);
+
+  test('zkp0 must reject off-curve C (G1 on-curve check)', async () => {
+    const proof = parseProof(vk, PROOF_PATH);
+    const auxWitness = AuXWitness.parse(AUX_PATH);
+
+    const origY = proof.C.y.toBigInt();
+    const tamperedY = (origY + 1n) % BN254_P;
+    const lhs = (tamperedY * tamperedY) % BN254_P;
+    const x = proof.C.x.toBigInt();
+    const rhs = (((x * x) % BN254_P) * x + 3n) % BN254_P;
+    expect(lhs).not.toBe(rhs);
+
+    const tamperedProof = {
+      ...proof,
+      C: new G1Affine({ x: proof.C.x, y: FpC.from(tamperedY) }),
+    };
+
+    const wt = new WitnessTracker(tamperedProof, auxWitness);
+    const [acc_0, lines_0, all_b_lines] = wt.in0();
+    const cin0 = Poseidon.hashPacked(Accumulator, acc_0);
+
+    await expect(
+      zkp0.compute(cin0, acc_0, lines_0, all_b_lines)
+    ).rejects.toThrow();
+  }, 600_000);
+
+  test('zkp0 must reject off-curve PI (G1 on-curve check)', async () => {
+    const proof = parseProof(vk, PROOF_PATH);
+    const auxWitness = AuXWitness.parse(AUX_PATH);
+
+    const origY = proof.PI.y.toBigInt();
+    const tamperedY = (origY + 1n) % BN254_P;
+    const lhs = (tamperedY * tamperedY) % BN254_P;
+    const x = proof.PI.x.toBigInt();
+    const rhs = (((x * x) % BN254_P) * x + 3n) % BN254_P;
+    expect(lhs).not.toBe(rhs);
+
+    const tamperedProof = {
+      ...proof,
+      PI: new G1Affine({ x: proof.PI.x, y: FpC.from(tamperedY) }),
+    };
+
+    const wt = new WitnessTracker(tamperedProof, auxWitness);
+    const [acc_0, lines_0, all_b_lines] = wt.in0();
+    const cin0 = Poseidon.hashPacked(Accumulator, acc_0);
+
+    await expect(
+      zkp0.compute(cin0, acc_0, lines_0, all_b_lines)
+    ).rejects.toThrow();
+  }, 600_000);
+});
+
+describe('regression_ec50d_groth16_g2_oncurve', () => {
+  beforeAll(async () => {
+    await zkp6.compile({ cache: Cache.FileSystem(CACHE_DIR) });
+  }, 600_000);
+
+  afterAll(() => {
+    rmSync(CACHE_DIR, { recursive: true, force: true });
+  });
+
+  // Tests the G2 on-curve check only (y^2 = x^3 + b_twist).
+  // Does NOT exercise the subgroup check: the on-curve check rejects before it.
+  test('zkp6 must reject off-curve B (G2 on-curve check)', async () => {
+    const proof = parseProof(vk, PROOF_PATH);
+    const auxWitness = AuXWitness.parse(AUX_PATH);
+
+    const origC0 = proof.B.y.c0.toBigInt();
+    const tamperedC0 = (origC0 + 1n) % BN254_P;
+
+    const tamperedProof = {
+      ...proof,
+      B: new G2Affine({
+        x: proof.B.x,
+        y: new Fp2({ c0: FpC.from(tamperedC0), c1: proof.B.y.c1 }),
+      }),
+    };
+
+    const wt = new WitnessTracker(tamperedProof, auxWitness);
+    wt.in0();
+    wt.zkp0();
+    wt.zkp1();
+    wt.zkp2();
+    wt.zkp3();
+    wt.zkp4();
+    const [acc_6, lines_6] = wt.zkp5();
+    const all_b_lines = wt.b_lines;
+    const cin6 = Poseidon.hashPacked(Accumulator, acc_6);
+
+    await expect(
+      zkp6.compute(cin6, acc_6, lines_6, all_b_lines)
+    ).rejects.toThrow();
+  }, 600_000);
+
+  // Fails on missing subgroup check (bad B accepted) and on broken check (valid B rejected).
+  test('zkp6 subgroup check must reject bad B and accept valid B', async () => {
+    const proof = parseProof(vk, PROOF_PATH);
+    const auxWitness = AuXWitness.parse(AUX_PATH);
+
+    // Part 1: bad B (on twist curve, not in G2[r]) must be rejected
+    const badB = findTwistPointNotInSubgroup();
+    const badProof = { ...proof, B: badB };
+    const wtBad = new WitnessTracker(badProof, auxWitness);
+    wtBad.in0();
+    wtBad.zkp0();
+    wtBad.zkp1();
+    wtBad.zkp2();
+    wtBad.zkp3();
+    wtBad.zkp4();
+    const [acc_bad, lines_bad] = wtBad.zkp5();
+    const bad_b_lines = wtBad.b_lines;
+    const cin_bad = Poseidon.hashPacked(Accumulator, acc_bad);
+
+    await expect(
+      zkp6.compute(cin_bad, acc_bad, lines_bad, bad_b_lines)
+    ).rejects.toThrow();
+
+    // Part 2: valid B (on-curve and in G2[r]) must be accepted
+    const wtGood = new WitnessTracker(proof, auxWitness);
+    wtGood.in0();
+    wtGood.zkp0();
+    wtGood.zkp1();
+    wtGood.zkp2();
+    wtGood.zkp3();
+    wtGood.zkp4();
+    const [acc_good, lines_good] = wtGood.zkp5();
+    const good_b_lines = wtGood.b_lines;
+    const cin_good = Poseidon.hashPacked(Accumulator, acc_good);
+
+    const result = await zkp6.compute(cin_good, acc_good, lines_good, good_b_lines);
+    expect(result.proof).toBeDefined();
+  }, 600_000);
+});

--- a/src/groth/recursion/zkp0.ts
+++ b/src/groth/recursion/zkp0.ts
@@ -36,6 +36,13 @@ const zkp0 = ZkProgram({
         input.assertEquals(Poseidon.hashPacked(Accumulator, acc));
         acc.state.g_digest.assertEquals(ArrayListHasher.hash(lines_hashes));
 
+        // G1 on-curve checks: BN254 G1 has prime order so on-curve implies subgroup membership.
+        // negA, C, PI are prover-supplied and enter as raw coordinates, so we assert
+        // y^2 = x^3 + 3 here at first use.
+        acc.proof.negA.assertOnCurve();
+        acc.proof.C.assertOnCurve();
+        acc.proof.PI.assertOnCurve();
+
         const a_cache = new AffineCache(acc.proof.negA);
         const c_cache = new AffineCache(acc.proof.C);
         const pi_cache = new AffineCache(acc.proof.PI);

--- a/src/groth/recursion/zkp6.ts
+++ b/src/groth/recursion/zkp6.ts
@@ -3,6 +3,7 @@ import { ZkProgram, Field, Poseidon, Provable } from 'o1js';
 import { Accumulator } from './data.js';
 import { Fp12 } from '../../towers/fp12.js';
 import { ATE_LOOP_COUNT } from '../../towers/consts.js';
+import { B_TWIST } from '../../towers/precomputed.js';
 import { ArrayListHasher } from '../../array_list_hasher.js';
 import { AffineCache } from '../../lines/precompute.js';
 import { VK } from '../vk_from_env.js';
@@ -34,6 +35,11 @@ const zkp6 = ZkProgram({
       ) {
         input.assertEquals(Poseidon.hashPacked(Accumulator, acc));
         acc.state.g_digest.assertEquals(ArrayListHasher.hash(lines_hashes));
+
+        // G2 on-curve check: y^2 = x^3 + b_twist
+        const B_y_sq = acc.proof.B.y.square();
+        const B_x_cu = acc.proof.B.x.square().mul(acc.proof.B.x);
+        B_y_sq.assert_equals(B_x_cu.add(B_TWIST));
 
         const a_cache = new AffineCache(acc.proof.negA);
         const c_cache = new AffineCache(acc.proof.C);
@@ -112,6 +118,16 @@ const zkp6 = ZkProgram({
 
         let pi_2_B = piB.negative_frobenius();
         b_line.assert_is_line(T, pi_2_B);
+        // Add -pi^2(B) to T
+        T = T.add_from_line(b_line.lambda, pi_2_B);
+        // G2 subgroup check: the BN254 endomorphism relation is
+        // [6u+2]B + pi(B) - pi^2(B) + pi^3(B) = O
+        // (Vercauteren, "Optimal Pairings", Section IV, W(x) = [6x+2, 1, -1, 1])
+        // https://www.esat.kuleuven.be/cosic/publications/article-1039.pdf
+        // After adding pi(B) and -pi^2(B), T = -pi^3(B) for B in G2[r].
+        const pi_3_B = pi_2_B.neg().frobenius();
+        T.x.assert_equals(pi_3_B.x);
+        T.y.assert_equals(pi_3_B.y.neg());
 
         g = g.sparse_mul(b_line.psi(a_cache));
         g = g.sparse_mul(delta_line.psi(c_cache));

--- a/src/groth/witness_tracker.ts
+++ b/src/groth/witness_tracker.ts
@@ -86,6 +86,21 @@ class WitnessTracker {
       frob_b_lines[0].lambda,
       piB
     );
+
+    // Dev sanity check, not a security boundary. Enforced in-circuit by zkp6.
+    // G2 subgroup check: the BN254 endomorphism relation is
+    // [6u+2]B + pi(B) - pi^2(B) + pi^3(B) = O
+    // (Vercauteren, "Optimal Pairings", Section IV, W(x) = [6x+2, 1, -1, 1])
+    // https://www.esat.kuleuven.be/cosic/publications/article-1039.pdf
+    // After adding pi(B) and -pi^2(B), T = -pi^3(B) for B in G2[r].
+    const pi_2_B = piB.negative_frobenius();
+    this.acc.state.T = this.acc.state.T.add_from_line(
+      frob_b_lines[1].lambda,
+      pi_2_B
+    );
+    const pi_3_B = pi_2_B.neg().frobenius();
+    this.acc.state.T.x.assert_equals(pi_3_B.x);
+    this.acc.state.T.y.assert_equals(pi_3_B.y.neg());
   }
 
   in0(): [Accumulator, Array<Field>, Array<G2Line>] {

--- a/src/plonk/ec50d_regression.spec.ts
+++ b/src/plonk/ec50d_regression.spec.ts
@@ -1,0 +1,149 @@
+import { rmSync } from 'fs';
+import { Cache, Poseidon } from 'o1js';
+import { Sp1PlonkProof, deserializeProof } from './proof.js';
+import { Sp1PlonkFiatShamir } from './fiat-shamir/index.js';
+import { StateUntilPairing, empty } from './state.js';
+import { Accumulator } from './accumulator.js';
+import { parsePublicInputs } from './parse_pi.js';
+import { FpC, FrC } from '../towers/index.js';
+import { zkp0 } from './recursion/zkp0.js';
+
+const BN254_P =
+  21888242871839275222246405745257275088696311157297823662689037894645226208583n;
+
+const CACHE_DIR = './cache_ec50d_plonk';
+
+const hexProof =
+  '0x2fa6371b5f35e61b6ee787a62f9b9d2ab098c01a69c567936a516b6a30d724090f3acd44d559006b3c80ae52ef31bdfb0d44d203f078b803a5817e3155b75c172ce81bfce68297ffbbfd99b14103062a8e9961545e519d165659c9b7f55dfee31c22c3ffc0357f6a444ebf34f863500658708146821f7311b96561684f0c5427051f886e102d3dd013716b9135c9930cb2d586fb11174ef830e48ca1921308241bc56c5cc5299e3ac08cd6da72a38335ac862278fe8e9ebfe8993d08f3dbab0014f70705f8afecc117a14a985f352399d77b30749216cc3ac96cf8b8aaa1183209bb06da94df7869b93bec52c74a895e46146a4038ec90d877181bf5045c5e550e81bbfd082045362b977f731ee4fef04f4f81b504a556e85ca07d389b9c968f1335eacf508bb3144087c63f961bb3fa76d99c147e80ce77224729f87939691b0e821573fa2c5514a8b6b5577843879c2933b5f7b6113a6f29e1fa7ac64518b11fae7b000ebf59a769976544cd3875650fc844860426363b26fc7310eebef5e620cd8a3343510e1dd99466036de5d6f82297b800a8730ad1cba49f6915e62fd4070b8d69efb6a993795565883363abc818be3baefe57021db0e9129b31c5bda4276b713da355f876101be16aca930418068bb26a87f16e87abcda02341a43aa12a8b1837c44c580465b01614d069776f12fb63bd901cff54362f7829d0ea19881d032ff5624a2a6efe366915d7d98de4128d6ae924defbc9ac60708e2991acdc0bc5fd8a5c704ecf295f6bfeb7a93c51e7cff86bb2e018d838cca098b83d3acc1b74ae28d432876e0bf2e3df8773fdc79f4312c2da8472ea2ce2fbe12b92d3d32411b806bdb74428b584c066f2cae5e947d58827e8d093324756c010d5a732a1254fe6790b5e6afa3df946fe1c2aee5b764da69c711684e7e5305a3dddf9bfab2c166eeefaaaa3ac9e97f5d8a731f33b0c5728348d12e975801043e7038babd406c904a6771994738e992240b03669d62cdc734f586f943e8c7e21513ba60adb0ce1fa79a3637b7b7b97134d029b5091aa978023c3ef1a40c8837c8fd492177a014760a68808b42da6565350376d1b7e793899e0b4028aa052265a01a512f2860a2abb7d20db39520ebb97e29ef40d05d1e4cdd399f91e42414b796e0657183101bcf700f9490eac8328dbfd7790f0b506b0218e441908a72d9128cf6b750b5a';
+const programVk =
+  '43461131588686223641337899419912555996095376523616191917604125452674317300';
+const piHex =
+  '0x000000000093544016227b1189eb5e8f87f888a095a94d580be01ba299a7258bfb2df338dc407e1f00000000009354603808741da450ca33951bbaf45c8e3575e87df6a923a477f04d1c2e509946df6d081051a57085376d588d45812d060de9efc1c21a031fe780301989ed8904ae5e00000000000000000000000000000000000000000000000000000000000000005dde454730f62c0a078137ecdfd85dec121fee45ac94aa90a78bb18ff2edca9d';
+const pi2Hex = '0';
+const pi3Hex =
+  '248831628400185611740479071450564250193912070693925013182243127282342200944';
+const pi4Hex = '0';
+
+type PointField =
+  | 'l_com_y'
+  | 'r_com_y'
+  | 'o_com_y'
+  | 'qcp_0_wire_y'
+  | 'grand_product_y'
+  | 'h0_y'
+  | 'h1_y'
+  | 'h2_y'
+  | 'batch_opening_at_zeta_y'
+  | 'batch_opening_at_zeta_omega_y';
+
+type XField =
+  | 'l_com_x'
+  | 'r_com_x'
+  | 'o_com_x'
+  | 'qcp_0_wire_x'
+  | 'grand_product_x'
+  | 'h0_x'
+  | 'h1_x'
+  | 'h2_x'
+  | 'batch_opening_at_zeta_x'
+  | 'batch_opening_at_zeta_omega_x';
+
+function makeAcc(): Accumulator {
+  const [pi0, pi1] = parsePublicInputs(programVk, piHex);
+  const proof = new Sp1PlonkProof(deserializeProof(hexProof));
+  const fs = Sp1PlonkFiatShamir.empty();
+  const state = new StateUntilPairing(
+    empty(pi0, pi1, FrC.from(pi2Hex), FrC.from(pi3Hex), FrC.from(pi4Hex))
+  );
+  return new Accumulator({ proof, fs, state });
+}
+
+function tamperPoint(acc: Accumulator, yField: PointField, xField: XField): void {
+  const origY = (acc.proof[yField] as FpC).toBigInt();
+  const tamperedY = (origY + 1n) % BN254_P;
+  const lhs = (tamperedY * tamperedY) % BN254_P;
+  const x = (acc.proof[xField] as FpC).toBigInt();
+  const rhs = (((x * x) % BN254_P) * x + 3n) % BN254_P;
+  if (lhs === rhs) throw new Error(`tampered ${yField} is still on curve`);
+  (acc.proof as unknown as Record<string, unknown>)[yField] = FpC.from(tamperedY);
+}
+
+describe('regression_ec50d_plonk_oncurve', () => {
+  beforeAll(async () => {
+    await zkp0.compile({ cache: Cache.FileSystem(CACHE_DIR) });
+  }, 600_000);
+
+  afterAll(() => {
+    rmSync(CACHE_DIR, { recursive: true, force: true });
+  });
+
+  test('zkp0 must reject off-curve l_com', async () => {
+    const acc = makeAcc();
+    tamperPoint(acc, 'l_com_y', 'l_com_x');
+    const cin0 = Poseidon.hashPacked(Accumulator, acc);
+    await expect(zkp0.compute(cin0, acc)).rejects.toThrow();
+  }, 600_000);
+
+  test('zkp0 must reject off-curve r_com', async () => {
+    const acc = makeAcc();
+    tamperPoint(acc, 'r_com_y', 'r_com_x');
+    const cin0 = Poseidon.hashPacked(Accumulator, acc);
+    await expect(zkp0.compute(cin0, acc)).rejects.toThrow();
+  }, 600_000);
+
+  test('zkp0 must reject off-curve o_com', async () => {
+    const acc = makeAcc();
+    tamperPoint(acc, 'o_com_y', 'o_com_x');
+    const cin0 = Poseidon.hashPacked(Accumulator, acc);
+    await expect(zkp0.compute(cin0, acc)).rejects.toThrow();
+  }, 600_000);
+
+  test('zkp0 must reject off-curve qcp_0_wire', async () => {
+    const acc = makeAcc();
+    tamperPoint(acc, 'qcp_0_wire_y', 'qcp_0_wire_x');
+    const cin0 = Poseidon.hashPacked(Accumulator, acc);
+    await expect(zkp0.compute(cin0, acc)).rejects.toThrow();
+  }, 600_000);
+
+  test('zkp0 must reject off-curve grand_product', async () => {
+    const acc = makeAcc();
+    tamperPoint(acc, 'grand_product_y', 'grand_product_x');
+    const cin0 = Poseidon.hashPacked(Accumulator, acc);
+    await expect(zkp0.compute(cin0, acc)).rejects.toThrow();
+  }, 600_000);
+
+  test('zkp0 must reject off-curve h0', async () => {
+    const acc = makeAcc();
+    tamperPoint(acc, 'h0_y', 'h0_x');
+    const cin0 = Poseidon.hashPacked(Accumulator, acc);
+    await expect(zkp0.compute(cin0, acc)).rejects.toThrow();
+  }, 600_000);
+
+  test('zkp0 must reject off-curve h1', async () => {
+    const acc = makeAcc();
+    tamperPoint(acc, 'h1_y', 'h1_x');
+    const cin0 = Poseidon.hashPacked(Accumulator, acc);
+    await expect(zkp0.compute(cin0, acc)).rejects.toThrow();
+  }, 600_000);
+
+  test('zkp0 must reject off-curve h2', async () => {
+    const acc = makeAcc();
+    tamperPoint(acc, 'h2_y', 'h2_x');
+    const cin0 = Poseidon.hashPacked(Accumulator, acc);
+    await expect(zkp0.compute(cin0, acc)).rejects.toThrow();
+  }, 600_000);
+
+  test('zkp0 must reject off-curve batch_opening_at_zeta', async () => {
+    const acc = makeAcc();
+    tamperPoint(acc, 'batch_opening_at_zeta_y', 'batch_opening_at_zeta_x');
+    const cin0 = Poseidon.hashPacked(Accumulator, acc);
+    await expect(zkp0.compute(cin0, acc)).rejects.toThrow();
+  }, 600_000);
+
+  test('zkp0 must reject off-curve batch_opening_at_zeta_omega', async () => {
+    const acc = makeAcc();
+    tamperPoint(acc, 'batch_opening_at_zeta_omega_y', 'batch_opening_at_zeta_omega_x');
+    const cin0 = Poseidon.hashPacked(Accumulator, acc);
+    await expect(zkp0.compute(cin0, acc)).rejects.toThrow();
+  }, 600_000);
+});

--- a/src/plonk/recursion/zkp0.ts
+++ b/src/plonk/recursion/zkp0.ts
@@ -1,6 +1,7 @@
 import { ZkProgram, Field, Poseidon } from 'o1js';
 import { Accumulator } from '../accumulator.js';
 import { VK } from '../vk.js';
+import { G1Affine } from '../../ec/index.js';
 
 // ~ 52792
 const zkp0 = ZkProgram({
@@ -13,6 +14,20 @@ const zkp0 = ZkProgram({
       async method(input: Field, acc: Accumulator) {
         const inDigest = Poseidon.hashPacked(Accumulator, acc);
         inDigest.assertEquals(input);
+
+        // G1 on-curve checks: BN254 G1 has prime order so on-curve implies subgroup membership.
+        // All 10 prover-supplied points enter as raw coordinates, so we assert
+        // y^2 = x^3 + 3 here at first use.
+        new G1Affine({ x: acc.proof.l_com_x, y: acc.proof.l_com_y }).assertOnCurve();
+        new G1Affine({ x: acc.proof.r_com_x, y: acc.proof.r_com_y }).assertOnCurve();
+        new G1Affine({ x: acc.proof.o_com_x, y: acc.proof.o_com_y }).assertOnCurve();
+        new G1Affine({ x: acc.proof.qcp_0_wire_x, y: acc.proof.qcp_0_wire_y }).assertOnCurve();
+        new G1Affine({ x: acc.proof.grand_product_x, y: acc.proof.grand_product_y }).assertOnCurve();
+        new G1Affine({ x: acc.proof.h0_x, y: acc.proof.h0_y }).assertOnCurve();
+        new G1Affine({ x: acc.proof.h1_x, y: acc.proof.h1_y }).assertOnCurve();
+        new G1Affine({ x: acc.proof.h2_x, y: acc.proof.h2_y }).assertOnCurve();
+        new G1Affine({ x: acc.proof.batch_opening_at_zeta_x, y: acc.proof.batch_opening_at_zeta_y }).assertOnCurve();
+        new G1Affine({ x: acc.proof.batch_opening_at_zeta_omega_x, y: acc.proof.batch_opening_at_zeta_omega_y }).assertOnCurve();
 
         // SP1 v5: only pi0/pi1 were hashed into gamma.
         // SP1 v6: pi2/pi3/pi4 (exit_code/vk_root/proof_nonce) must also be hashed.

--- a/src/towers/precomputed.ts
+++ b/src/towers/precomputed.ts
@@ -69,4 +69,7 @@ const GAMMA_3S = [
   GAMMA_1S[4].mul(GAMMA_2S[4]),
 ];
 
-export { fp2_non_residue, GAMMA_1S, GAMMA_2S, GAMMA_3S, NEG_GAMMA_13 };
+// BN254 G2 twist curve constant: b_twist = 3 / (9 + u)
+const B_TWIST = new Fp2({ c0: FpC.from(3n), c1: FpC.from(0n) }).mul(fp2_non_residue.inverse());
+
+export { fp2_non_residue, GAMMA_1S, GAMMA_2S, GAMMA_3S, NEG_GAMMA_13, B_TWIST };


### PR DESCRIPTION
- [CHORE: audit ec50d commit 1](https://github.com/Nori-zk/proof-conversion/commit/9bed8442782b125c347440c102bf1f5c45dc728a), regression tests exposing missing on-curve and subgroup checks on prover-supplied proof points, groth16 5 suites covering negA C PI via zkp0, B on-curve via zkp6, and combined G2 subgroup check via zkp6 (0 pass, 5 fail), plonk 10 suites covering all G1 points via zkp0 (0 pass 10 fail), changelog documenting finding, response, discussion and results.

- [FIX: audit ec50d commit 2](https://github.com/Nori-zk/proof-conversion/commit/67209daba2e68b7dc1093e53a74b518daea5ef26), G1 on-curve checks added to groth16 zkp0 (negA, C, PI) and plonk zkp0 (all 10 points) via new G1Affine.assertOnCurve(), G2 on-curve check (y^2 = x^3 + b_twist) and G2 subgroup check added to groth16 zkp6 enforcing full 4-term endomorphism relation [6u+2]B + pi(B) - pi^2(B) + pi^3(B) = O, B_TWIST constant added to precomputed.ts, off-circuit G2 subgroup sanity check added to witness_tracker.ts, all regression tests pass (5 groth16 + 10 plonk, 15 pass 0 fail), changelog updated.