### PR TITLE
Chore/integration fix audit fix audit adcd3 - Fix/audit adcd3: Groth16 proof parser does not validate that piN keys are sequential

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,21 @@ Results:
 - Proof regression tests: 19 fail, 5 pass. Contiguity, schema, optional-field, and exact-shape checks all absent.
 - VK regression tests: 10 fail, 14 pass. Contiguity, optional-field, and exact-shape checks absent; basic missing-field checks already present in current code.
 
+### Commit 2 - Fix applied
+
+- **`src/groth/proof.ts`**: `detectInputCountFromProof` updated with `assertExactStructure` schema validation and explicit `piN` contiguity check. `isO1jsProof` schema defined using `isAffinePoint2d`, `isComplexAffinePoint2d`, and `isOptionalString`.
+- **`src/groth/vk.ts`**: `GrothVk.parse` updated with `assertExactStructure` schema validation and explicit `icN` contiguity check. `isGrothVk` schema defined using `isAffinePoint2d`, `isComplexAffinePoint2d`, `isField12`, and `isOptionalAffinePoint2d`. FIXME comment removed.
+- **`src/api/validation/validation.ts`**: `assertExactStructure` patched to treat missing keys as valid when the schema validator accepts `undefined`, enabling optional field support.
+- **`src/api/validation/guards/crypto.ts`**: `isAffinePoint2d` and `isComplexAffinePoint2d` updated to check exact key count in addition to key presence. `isField12` updated to check `Object.keys(obj).length === 12`. `isOptionalAffinePoint2d` added.
+- **`src/api/validation/guards/strings.ts`**: New file. `isOptionalString` defined here with docstring.
+- **`src/api/validation/guards/index.ts`**: `strings.ts` added to exports.
+
+Results:
+
+- Proof regression tests: 24 pass, 0 fail.
+- VK regression tests: 24 pass, 0 fail.
+- Existing validation tests (`src/api/validation/guards/test.spec.ts`): 14 pass, 0 fail.
+
 # 18/5/26 - Audit B1114: Disabled layer1 subtrees unconstrained, allowing forgery of SP1 PLONK public inputs
 
 ## Finding (verbatim)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,70 @@
+# 02/06/26 - Audit adcd3: Groth16 proof and VK parsers do not validate that piN and icN keys are contiguous
+
+## Finding (verbatim)
+
+Finding adcd3: Groth16 proof parser does not validate that `piN` keys are sequential
+
+src/groth/proof.ts assumes that public inputs in the proof JSON are stored under contiguous keys pi1 through pi{n}. The input count is detected as follows:
+
+```typescript
+export function detectInputCountFromProof(path: string): number {
+  const json: O1jsProof = JSON.parse(fs.readFileSync(path, 'utf-8'));
+  let count = 0;
+  for (let i = 1; i <= 6; i++) {
+    if (json[`pi${i}` as PiKey]) count++;
+  }
+  return count;
+}
+```
+
+The proof is then parsed using the detected inputCount:
+
+```typescript
+      const publicInputs: FrC[] = [];
+      for (let i = 1; i <= inputCount; i++) {
+        const key = `pi${i}` as PiKey;
+        const val = json[key];
+        if (val) {
+          publicInputs.push(FrC.from(val));
+        }
+      }
+      // ...
+      return new ProofClass({
+        // ...
+        pis: publicInputs,
+      });
+```
+
+Although pis is defined as Provable.Array(FrC.provable, inputCount) and expects exactly inputCount elements, a shorter array can be passed if some piN keys are absent. When this struct is later consumed by Provable.witness, it throws: Error: Expected array of length 3, got 0. This shouldn't have happened and indicates an internal bug.
+
+This is not exploitable, and in practice the piN values produced by the computing plan are always sequential, so the impact is limited. We are flagging this as a code maturity concern: we recommend adding a simple validation step to verify that the detected keys are strictly sequential before proceeding with parsing.
+
+## Response
+
+The finding is acknowledged. In the course of addressing it, scope was expanded to cover `GrothVk.parse` (`src/groth/vk.ts`) which has the same class of issue for `icN` keys - the VK parser collects whatever `ic0` to `ic6` keys are present without checking contiguity, and a FIXME comment in the code (`// FIXME CHECKME what if we have skipped some??`) confirms this was already known. Both parsers will be fixed together: `assertExactStructure` added for schema validation and an explicit contiguity check for sequential key ordering.
+
+In the course of writing tests, three further bugs were identified in the validation layer:
+
+- `isAffinePoint2d` (`src/api/validation/guards/crypto.ts`): used `'x' in obj && 'y' in obj` without checking key count, so `{ x: '1', y: '2', extra: 'bad' }` passed validation.
+- `isComplexAffinePoint2d` (`src/api/validation/guards/crypto.ts`): same issue - checked for presence of the four expected keys but not exclusivity.
+- `isField12` (`src/api/validation/guards/crypto.ts`): same issue - checked all 12 keys were present but did not reject objects with additional keys.
+- `assertExactStructure` (`src/api/validation/validation.ts`): treated all schema keys as required, so optional fields (wrapped with `isOptionalField`) could not be absent from the validated object - this was required to support optional `piN` and `icN` fields in the proof and VK schemas.
+
+All four will be fixed in commit 2 alongside the parser fixes.
+
+### Commit 1 - Regression tests exposing missing contiguity and exact-shape validation
+
+- **Regression tests** (`src/groth/adcd3_regression.spec.ts`): 24 tests covering `detectInputCountFromProof` - valid contiguous sequences (0 through 6 inputs), non-contiguous sequences (gaps at various positions), schema violations (missing/wrong-type fields), and unknown fields (pi0, pi7, extra keys on top-level and nested objects including negA, C, B). On unpatched code 19 fail, 5 pass.
+- **Regression tests** (`src/groth/adcd3_vk_regression.spec.ts`): 24 tests covering `GrothVk.parse` - valid contiguous ic sequences (ic0 through ic3), non-contiguous sequences, missing required fields, wrong field types, and unknown fields (top-level and nested: ic0, delta, gamma, alpha_beta, w27). On unpatched code 10 fail, 14 pass.
+
+Run: `npm run test:jest -- src/groth/adcd3_regression.spec.ts`
+Run: `npm run test:jest -- src/groth/adcd3_vk_regression.spec.ts`
+
+Results:
+
+- Proof regression tests: 19 fail, 5 pass. Contiguity, schema, optional-field, and exact-shape checks all absent.
+- VK regression tests: 10 fail, 14 pass. Contiguity, optional-field, and exact-shape checks absent; basic missing-field checks already present in current code.
+
 # 18/5/26 - Audit B1114: Disabled layer1 subtrees unconstrained, allowing forgery of SP1 PLONK public inputs
 
 ## Finding (verbatim)

--- a/src/api/validation/guards/crypto.ts
+++ b/src/api/validation/guards/crypto.ts
@@ -7,6 +7,7 @@ import type {
 } from '@nori-zk/proof-conversion-utils';
 import { guard } from './core.js';
 import { isString } from './primitives.js';
+import { isOptionalField } from './modifiers.js';
 
 // ============================================================================
 // OBJECT/STRUCTURE GUARDS - For cryptographic types
@@ -32,7 +33,8 @@ export const isAffinePoint2d = guard(function isAffinePoint2d(
 ): val is AffinePoint2d {
   if (!val || typeof val !== 'object') return false;
   const obj = val as Record<string, unknown>;
-  return 'x' in obj && 'y' in obj && isString(obj.x) && isString(obj.y);
+  const keys = Object.keys(obj);
+  return keys.length === 2 && 'x' in obj && 'y' in obj && isString(obj.x) && isString(obj.y);
 });
 
 /**
@@ -55,7 +57,9 @@ export const isComplexAffinePoint2d = guard(function isComplexAffinePoint2d(
 ): val is ComplexAffinePoint2d {
   if (!val || typeof val !== 'object') return false;
   const obj = val as Record<string, unknown>;
+  const keys = Object.keys(obj);
   return (
+    keys.length === 4 &&
     'x_c0' in obj &&
     'x_c1' in obj &&
     'y_c0' in obj &&
@@ -101,7 +105,7 @@ export const isField12 = guard(function isField12(
     'h20',
     'h21',
   ];
-  return keys.every((key) => key in obj && isString(obj[key]));
+  return Object.keys(obj).length === keys.length && keys.every((key) => key in obj && isString(obj[key]));
 });
 
 /**
@@ -161,3 +165,17 @@ export const isComplexProjectivePoint = guard(function isComplexProjectivePoint(
     )
   );
 });
+
+/**
+ * Type guard validator for optional G1 affine points.
+ * Returns a ValidatorFn that narrows the type to `AffinePoint2d | undefined` on success.
+ *
+ * @returns ValidatorFn<AffinePoint2d | undefined> - Validator function for AffinePoint2d or undefined values
+ *
+ * @example
+ * const validator = isOptionalAffinePoint2d;
+ * if (validator(value)) {
+ *   // value is narrowed to type: AffinePoint2d | undefined
+ * }
+ */
+export const isOptionalAffinePoint2d = isOptionalField(isAffinePoint2d);

--- a/src/api/validation/guards/index.ts
+++ b/src/api/validation/guards/index.ts
@@ -15,3 +15,4 @@ export * from './arrays.js';
 export * from './crypto.js';
 export * from './modifiers.js';
 export * from './types.js';
+export * from './strings.js';

--- a/src/api/validation/guards/strings.ts
+++ b/src/api/validation/guards/strings.ts
@@ -1,0 +1,16 @@
+import { isOptionalField } from "./modifiers.js";
+import { isString } from "./primitives.js";
+
+/**
+ * Type guard validator for optional strings.
+ * Returns a ValidatorFn that narrows the type to `string | undefined` on success.
+ *
+ * @returns ValidatorFn<string | undefined> - Validator function for string or undefined values
+ *
+ * @example
+ * const validator = isOptionalString;
+ * if (validator(value)) {
+ *   // value is narrowed to type: string | undefined
+ * }
+ */
+export const isOptionalString = isOptionalField(isString);

--- a/src/api/validation/validation.ts
+++ b/src/api/validation/validation.ts
@@ -65,12 +65,13 @@ export function assertExactStructure<S extends SchemaObject>(
     // Build path using bracket notation for consistency: root["key"]
     const currentPath = pathPrefix ? `${pathPrefix}["${key}"]` : key;
 
+    const rule = castSchema[key];
+
     if (!(key in castObj)) {
+      if (typeof rule === 'function' && rule(undefined)) continue;
       errors.push(`${currentPath}: missing required key`);
       continue;
     }
-
-    const rule = castSchema[key];
     const value = castObj[key];
 
     if (typeof rule === 'function') {

--- a/src/groth/adcd3_regression.spec.ts
+++ b/src/groth/adcd3_regression.spec.ts
@@ -1,0 +1,132 @@
+import { writeFileSync, unlinkSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { detectInputCountFromProof } from './proof.js';
+
+const VALID_NEG_A = { x: '16465199099708604290698553000024942000051030364759839088954586362243760185403', y: '17690359568564825813235988832215237195831246832056909949821693820324615702030' };
+const VALID_B = { x_c0: '20076621026680381759767634077167710158570125456580059736389163589252903861997', x_c1: '8939596936503745624468413156089285325774309438533412822132357238045755689387', y_c0: '111879341840300391556371653123940615424189534247854096298516707026393487948', y_c1: '7719123513247232282802073769919057076444760653726977674407327771459600820251' };
+const VALID_C = { x: '10184405014965771627427034456113644883671783030647002464387923536809721376302', y: '3331725942843591742687069662771052794291623321043694393039994836222102831251' };
+
+const BASE_PROOF = { negA: VALID_NEG_A, B: VALID_B, C: VALID_C };
+
+const paths: string[] = [];
+
+function tmp(obj: object): string {
+  const path = join(tmpdir(), `adcd3_${Date.now()}_${Math.random()}.json`);
+  writeFileSync(path, JSON.stringify(obj));
+  paths.push(path);
+  return path;
+}
+
+afterAll(() => paths.forEach(p => unlinkSync(p)));
+
+describe('regression_adcd3_pi_contiguity', () => {
+
+  describe('valid - contiguous pi sequences', () => {
+    test('zero pi inputs (minimum) returns 0', () => {
+      expect(detectInputCountFromProof(tmp(BASE_PROOF))).toBe(0);
+    });
+
+    test('pi1 only returns 1', () => {
+      expect(detectInputCountFromProof(tmp({ ...BASE_PROOF, pi1: '1' }))).toBe(1);
+    });
+
+    test('pi1 pi2 returns 2', () => {
+      expect(detectInputCountFromProof(tmp({ ...BASE_PROOF, pi1: '1', pi2: '2' }))).toBe(2);
+    });
+
+    test('pi1 through pi3 returns 3', () => {
+      expect(detectInputCountFromProof(tmp({ ...BASE_PROOF, pi1: '1', pi2: '2', pi3: '3' }))).toBe(3);
+    });
+
+    test('pi1 through pi6 (maximum) returns 6', () => {
+      expect(detectInputCountFromProof(tmp({ ...BASE_PROOF, pi1: '1', pi2: '2', pi3: '3', pi4: '4', pi5: '5', pi6: '6' }))).toBe(6);
+    });
+  });
+
+  describe('invalid - non-contiguous pi sequences', () => {
+    test('pi2 present without pi1 throws contiguous error', () => {
+      expect(() => detectInputCountFromProof(tmp({ ...BASE_PROOF, pi2: '2' }))).toThrow(/pi1.*contiguous/);
+    });
+
+    test('pi1 and pi3 with missing pi2 throws contiguous error', () => {
+      expect(() => detectInputCountFromProof(tmp({ ...BASE_PROOF, pi1: '1', pi3: '3' }))).toThrow(/pi2.*contiguous/);
+    });
+
+    test('pi1 pi2 pi4 with missing pi3 throws contiguous error', () => {
+      expect(() => detectInputCountFromProof(tmp({ ...BASE_PROOF, pi1: '1', pi2: '2', pi4: '4' }))).toThrow(/pi3.*contiguous/);
+    });
+
+    test('pi3 through pi6 with missing pi1 pi2 throws contiguous error', () => {
+      expect(() => detectInputCountFromProof(tmp({ ...BASE_PROOF, pi3: '3', pi4: '4', pi5: '5', pi6: '6' }))).toThrow(/pi1.*contiguous/);
+    });
+  });
+
+  describe('invalid - schema violations', () => {
+    test('missing negA throws', () => {
+      const { negA: _, ...noNegA } = BASE_PROOF;
+      expect(() => detectInputCountFromProof(tmp(noNegA))).toThrow();
+    });
+
+    test('missing B throws', () => {
+      const { B: _, ...noB } = BASE_PROOF;
+      expect(() => detectInputCountFromProof(tmp(noB))).toThrow();
+    });
+
+    test('missing C throws', () => {
+      const { C: _, ...noC } = BASE_PROOF;
+      expect(() => detectInputCountFromProof(tmp(noC))).toThrow();
+    });
+
+    test('negA.x as number instead of string throws', () => {
+      expect(() => detectInputCountFromProof(tmp({ ...BASE_PROOF, negA: { x: 123, y: '0' } }))).toThrow();
+    });
+
+    test('negA.y missing throws', () => {
+      expect(() => detectInputCountFromProof(tmp({ ...BASE_PROOF, negA: { x: '0' } }))).toThrow();
+    });
+
+    test('B missing x_c0 throws', () => {
+      const { x_c0: _, ...bNoXc0 } = VALID_B;
+      expect(() => detectInputCountFromProof(tmp({ ...BASE_PROOF, B: bNoXc0 }))).toThrow();
+    });
+
+    test('pi1 as number instead of string throws', () => {
+      expect(() => detectInputCountFromProof(tmp({ ...BASE_PROOF, pi1: 123 }))).toThrow();
+    });
+
+    test('pi1 as null throws', () => {
+      expect(() => detectInputCountFromProof(tmp({ ...BASE_PROOF, pi1: null }))).toThrow();
+    });
+
+    test('empty object throws', () => {
+      expect(() => detectInputCountFromProof(tmp({}))).toThrow();
+    });
+  });
+
+  describe('invalid - unknown fields', () => {
+    test('unknown top-level field throws', () => {
+      expect(() => detectInputCountFromProof(tmp({ ...BASE_PROOF, unknownField: 'foo' }))).toThrow();
+    });
+
+    test('pi7 (beyond maximum) throws', () => {
+      expect(() => detectInputCountFromProof(tmp({ ...BASE_PROOF, pi1: '1', pi7: '7' }))).toThrow();
+    });
+
+    test('pi0 throws', () => {
+      expect(() => detectInputCountFromProof(tmp({ ...BASE_PROOF, pi0: '0' }))).toThrow();
+    });
+
+    test('unknown field inside negA throws', () => {
+      expect(() => detectInputCountFromProof(tmp({ ...BASE_PROOF, negA: { ...VALID_NEG_A, extra: 'bad' } }))).toThrow();
+    });
+
+    test('unknown field inside C throws', () => {
+      expect(() => detectInputCountFromProof(tmp({ ...BASE_PROOF, C: { ...VALID_C, extra: 'bad' } }))).toThrow();
+    });
+
+    test('unknown field inside B throws', () => {
+      expect(() => detectInputCountFromProof(tmp({ ...BASE_PROOF, B: { ...VALID_B, extra: 'bad' } }))).toThrow();
+    });
+  });
+});

--- a/src/groth/adcd3_vk_regression.spec.ts
+++ b/src/groth/adcd3_vk_regression.spec.ts
@@ -1,0 +1,140 @@
+import { writeFileSync, unlinkSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { GrothVk } from './vk.js';
+
+const VALID_DELTA = { x_c0: '12043754404802191763554326994664886008979042643626290185762540825416902247219', x_c1: '1668323501672964604911431804142266013250380587483576094566949227275849579036', y_c0: '13740680757317479711909903993315946540841369848973133181051452051592786724563', y_c1: '7710631539206257456743780535472368339139328733484942210876916214502466455394' };
+const VALID_GAMMA = { x_c0: '10857046999023057135944570762232829481370756359578518086990519993285655852781', x_c1: '11559732032986387107991004021392285783925812861821192530917403151452391805634', y_c0: '8495653923123431417604973247489272438418190587263600148770280649306958101930', y_c1: '4082367875863433681332203403145435568316851327593401208105741076214120093531' };
+const VALID_ALPHA_BETA = { g00: '5697245924082314955838557878331368209814247075300951521701254589084804234970', g01: '6607404321972637550020783611836551818248636342709305900123466355480118576099', g10: '3670608949875518863244021916950733644062078743044974108285053440592297066931', g11: '541250262476899488042926921352922562849943764605667374596011538907110731629', g20: '18124534578366443052930374136100844352060568779165176942539622400742155990163', g21: '254425962675264208268606525222145870537081446419126819669512313449894617711', h00: '14682601387374107597061811864806746474418747695496995459538035046909465405682', h01: '380626998809465124537308088395106769155276843034064955773603619257287977827', h10: '20937581287674855219025710764445572864809573889072173538957685817558553170744', h11: '1875554049818610060118039934136718085309900630088668968527777353177281637676', h20: '10677133934211244973062689418678002923080465282453292613142034282094753864563', h21: '5217526782465309563115572197406844083015292505138779767346232600336410380272' };
+const VALID_W27 = { g00: '0', g01: '0', g10: '0', g11: '0', g20: '8204864362109909869166472767738877274689483185363591877943943203703805152849', g21: '17912368812864921115467448876996876278487602260484145953989158612875588124088', h00: '0', h01: '0', h10: '0', h11: '0', h20: '0', h21: '0' };
+
+const IC0 = { x: '8446592859352799428420270221449902464741693648963397251242447530457567083492', y: '1064796367193003797175961162477173481551615790032213185848276823815288302804' };
+const IC1 = { x: '3179835575189816632597428042194253779818690147323192973511715175294048485951', y: '20895841676865356752879376687052266198216014795822152491318012491767775979074' };
+const IC2 = { x: '5332723250224941161709478398807683311971555792614491788690328996478511465287', y: '21199491073419440416471372042641226693637837098357067793586556692319371762571' };
+const IC3 = { x: '12457994489566736295787256452575216703923664299075106359829199968023158780583', y: '19706766271952591897761291684837117091856807401404423804318744964752784280790' };
+
+const BASE_VK = { alpha_beta: VALID_ALPHA_BETA, delta: VALID_DELTA, gamma: VALID_GAMMA, w27: VALID_W27 };
+
+const paths: string[] = [];
+
+function tmp(obj: object): string {
+  const path = join(tmpdir(), `adcd3_vk_${Date.now()}_${Math.random()}.json`);
+  writeFileSync(path, JSON.stringify(obj));
+  paths.push(path);
+  return path;
+}
+
+afterAll(() => paths.forEach(p => unlinkSync(p)));
+
+describe('regression_adcd3_ic_contiguity', () => {
+
+  describe('valid - contiguous ic sequences', () => {
+    test('ic0 only (zero public inputs) parses successfully', () => {
+      expect(() => GrothVk.parse(tmp({ ...BASE_VK, ic0: IC0 }))).not.toThrow();
+    });
+
+    test('ic0 ic1 (one public input) parses successfully', () => {
+      expect(() => GrothVk.parse(tmp({ ...BASE_VK, ic0: IC0, ic1: IC1 }))).not.toThrow();
+    });
+
+    test('ic0 ic1 ic2 (two public inputs) parses successfully', () => {
+      expect(() => GrothVk.parse(tmp({ ...BASE_VK, ic0: IC0, ic1: IC1, ic2: IC2 }))).not.toThrow();
+    });
+
+    test('ic0 through ic3 (three public inputs) parses successfully', () => {
+      expect(() => GrothVk.parse(tmp({ ...BASE_VK, ic0: IC0, ic1: IC1, ic2: IC2, ic3: IC3 }))).not.toThrow();
+    });
+  });
+
+  describe('invalid - non-contiguous ic sequences', () => {
+    test('ic0 and ic2 with missing ic1 throws contiguous error', () => {
+      expect(() => GrothVk.parse(tmp({ ...BASE_VK, ic0: IC0, ic2: IC2 }))).toThrow(/ic1.*contiguous/);
+    });
+
+    test('ic0 ic1 ic3 with missing ic2 throws contiguous error', () => {
+      expect(() => GrothVk.parse(tmp({ ...BASE_VK, ic0: IC0, ic1: IC1, ic3: IC3 }))).toThrow(/ic2.*contiguous/);
+    });
+
+    test('ic1 present without ic0 throws', () => {
+      expect(() => GrothVk.parse(tmp({ ...BASE_VK, ic1: IC1 }))).toThrow();
+    });
+
+    test('ic2 ic3 without ic0 ic1 throws', () => {
+      expect(() => GrothVk.parse(tmp({ ...BASE_VK, ic2: IC2, ic3: IC3 }))).toThrow();
+    });
+  });
+
+  describe('invalid - missing required fields', () => {
+    test('no ic points at all throws', () => {
+      expect(() => GrothVk.parse(tmp(BASE_VK))).toThrow();
+    });
+
+    test('missing alpha_beta throws', () => {
+      const { alpha_beta: _, ...noAlphaBeta } = BASE_VK;
+      expect(() => GrothVk.parse(tmp({ ...noAlphaBeta, ic0: IC0 }))).toThrow();
+    });
+
+    test('missing delta throws', () => {
+      const { delta: _, ...noDelta } = BASE_VK;
+      expect(() => GrothVk.parse(tmp({ ...noDelta, ic0: IC0 }))).toThrow();
+    });
+
+    test('missing gamma throws', () => {
+      const { gamma: _, ...noGamma } = BASE_VK;
+      expect(() => GrothVk.parse(tmp({ ...noGamma, ic0: IC0 }))).toThrow();
+    });
+
+    test('missing w27 throws', () => {
+      const { w27: _, ...noW27 } = BASE_VK;
+      expect(() => GrothVk.parse(tmp({ ...noW27, ic0: IC0 }))).toThrow();
+    });
+
+    test('empty object throws', () => {
+      expect(() => GrothVk.parse(tmp({}))).toThrow();
+    });
+  });
+
+  describe('invalid - wrong field types', () => {
+    test('ic0.x as number throws', () => {
+      expect(() => GrothVk.parse(tmp({ ...BASE_VK, ic0: { x: 123, y: IC0.y } }))).toThrow();
+    });
+
+    test('ic0.y missing throws', () => {
+      expect(() => GrothVk.parse(tmp({ ...BASE_VK, ic0: { x: IC0.x } }))).toThrow();
+    });
+
+    test('delta.x_c0 as number throws', () => {
+      expect(() => GrothVk.parse(tmp({ ...BASE_VK, ic0: IC0, delta: { ...VALID_DELTA, x_c0: 123 } }))).toThrow();
+    });
+
+    test('alpha_beta field as number throws', () => {
+      expect(() => GrothVk.parse(tmp({ ...BASE_VK, ic0: IC0, alpha_beta: { ...VALID_ALPHA_BETA, g00: 123 } }))).toThrow();
+    });
+  });
+
+  describe('invalid - unknown fields', () => {
+    test('unknown top-level field throws', () => {
+      expect(() => GrothVk.parse(tmp({ ...BASE_VK, ic0: IC0, unknownField: 'foo' }))).toThrow();
+    });
+
+    test('unknown field inside ic0 throws', () => {
+      expect(() => GrothVk.parse(tmp({ ...BASE_VK, ic0: { ...IC0, extra: 'bad' } }))).toThrow();
+    });
+
+    test('unknown field inside delta throws', () => {
+      expect(() => GrothVk.parse(tmp({ ...BASE_VK, ic0: IC0, delta: { ...VALID_DELTA, extra: 'bad' } }))).toThrow();
+    });
+
+    test('unknown field inside gamma throws', () => {
+      expect(() => GrothVk.parse(tmp({ ...BASE_VK, ic0: IC0, gamma: { ...VALID_GAMMA, extra: 'bad' } }))).toThrow();
+    });
+
+    test('unknown field inside alpha_beta throws', () => {
+      expect(() => GrothVk.parse(tmp({ ...BASE_VK, ic0: IC0, alpha_beta: { ...VALID_ALPHA_BETA, extra: 'bad' } }))).toThrow();
+    });
+
+    test('unknown field inside w27 throws', () => {
+      expect(() => GrothVk.parse(tmp({ ...BASE_VK, ic0: IC0, w27: { ...VALID_W27, extra: 'bad' } }))).toThrow();
+    });
+  });
+});

--- a/src/groth/proof.ts
+++ b/src/groth/proof.ts
@@ -6,6 +6,7 @@ import { G2Line, computeLineCoeffs } from '../lines/index.js';
 import { computePI } from './compute_pi.js';
 import { GrothVk } from './vk.js';
 import type { O1jsProof } from '@nori-zk/proof-conversion-utils';
+import { assertExactStructure, isAffinePoint2d, isComplexAffinePoint2d, isOptionalString } from '../api/validation/index.js';
 
 export interface ProofData {
   negA: G1Affine;
@@ -119,12 +120,36 @@ function createProofClass(inputCount: number) {
   return ProofClass;
 }
 
+const isO1jsProof = {
+  negA: isAffinePoint2d,
+  B: isComplexAffinePoint2d,
+  C: isAffinePoint2d,
+  pi1: isOptionalString,
+  pi2: isOptionalString,
+  pi3: isOptionalString,
+  pi4: isOptionalString,
+  pi5: isOptionalString,
+  pi6: isOptionalString,
+}
+
 export function detectInputCountFromProof(path: string): number {
   const json: O1jsProof = JSON.parse(fs.readFileSync(path, 'utf-8'));
-  let count = 0;
-  for (let i = 1; i <= 6; i++) {
-    if (json[`pi${i}` as PiKey]) count++;
+  
+  // Runtime validation of O1jsProof schema, piN contiguous - if present.
+
+  assertExactStructure(json, isO1jsProof, 'o1jsProof');
+
+  const piIndices = Object.keys(json)
+    .filter((key) => /^pi\d+$/.test(key))
+    .map((key) => Number(key.slice(2)));
+  
+  const count = Math.max(...[0,...piIndices]);
+
+  for (let i = 1; i <= count; i++) {
+    if (!json[`pi${i}` as PiKey]) 
+      throw new Error(`'pi${i}' is missing when we expected up to 'pi${count}'. piN must be contiguous from pi1 to pi${count}`);
   }
+
   return count;
 }
 

--- a/src/groth/vk.ts
+++ b/src/groth/vk.ts
@@ -5,6 +5,21 @@ import fs from 'fs';
 import { bn254 } from '../ec/g1.js';
 import { ForeignCurve } from 'o1js';
 import { O1jsVK } from '@nori-zk/proof-conversion-utils';
+import { assertExactStructure, isAffinePoint2d, isComplexAffinePoint2d, isField12, isOptionalAffinePoint2d } from '../api/validation/index.js';
+
+const isGrothVk = {
+  alpha_beta: isField12,
+  delta: isComplexAffinePoint2d,
+  gamma: isComplexAffinePoint2d,
+  w27: isField12,
+  ic0: isAffinePoint2d,
+  ic1: isOptionalAffinePoint2d,
+  ic2: isOptionalAffinePoint2d,
+  ic3: isOptionalAffinePoint2d,
+  ic4: isOptionalAffinePoint2d,
+  ic5: isOptionalAffinePoint2d,
+  ic6: isOptionalAffinePoint2d,
+};
 
 // Flexible SerializedVk type supporting all possible IC points
 type SerializedVk = Omit<O1jsVK, 'alpha' | 'beta'>;
@@ -58,18 +73,21 @@ class GrothVk {
     const data = fs.readFileSync(path, 'utf-8');
     const obj: SerializedVk = JSON.parse(data);
 
-    // Detect available IC points from VK structure
-    const availableIcFields = Object.keys(obj)
-      .filter(key => key.startsWith('ic') && /^ic\d+$/.test(key))
-      .sort((a, b) => {
-        const numA = parseInt(a.substring(2));
-        const numB = parseInt(b.substring(2));
-        return numA - numB;
-      });
+    // Runtime validation of GrothVk schema and icN contiguity.
+    assertExactStructure(obj, isGrothVk, 'grothVk');
 
-    if (availableIcFields.length === 0 || !availableIcFields.includes('ic0')) {
-      throw new Error('VK must contain at least ic0 point');
+    const icIndices = Object.keys(obj)
+      .filter(key => /^ic\d+$/.test(key))
+      .map(key => Number(key.slice(2)));
+
+    const icCount = Math.max(...icIndices);
+
+    for (let i = 0; i <= icCount; i++) {
+      if (!obj[`ic${i}` as IcKey])
+        throw new Error(`'ic${i}' is missing when we expected up to 'ic${icCount}'. icN must be contiguous from ic0 to ic${icCount}`);
     }
+
+    const availableIcFields = Array.from({ length: icCount + 1 }, (_, i) => `ic${i}`);
 
     const dx = new Fp2({
       c0: FpC.from(obj.delta.x_c0),
@@ -94,7 +112,7 @@ class GrothVk {
     const alpha_beta = Fp12.loadFromJSON(obj.alpha_beta);
     const w27 = Fp12.loadFromJSON(obj.w27);
 
-    // Parse all available IC points FIXME CHECKME what if we have skipped some??
+    // Parse all available IC points
     const icPoints = availableIcFields.map(field => {
       const icData = obj[field as IcKey];
       if (!icData || !icData.x || !icData.y) {


### PR DESCRIPTION
- [CHORE: audit adcd3 commit 1](https://github.com/Nori-zk/proof-conversion/commit/93015b57e95f352ab4828a25ab6e397268976b95), regression tests exposing missing piN contiguity, icN contiguity, and exact-shape validation in crypto guards, proof spec 19 fail 5 pass, vk spec 10 fail 14 pass, changelog updated.
- [FIX: audit adcd3 commit 2](https://github.com/Nori-zk/proof-conversion/commit/4209fb0bb93e57665a54a49aa1138e013999b705), assertExactStructure and piN/icN contiguity checks added to proof and vk parsers, crypto guards patched to reject extra keys, optional field support added to assertExactStructure, all regression tests pass (48 pass 0 fail), changelog updated.
- [CHORE: integration merge](https://github.com/Nori-zk/proof-conversion/commit/4921e01e275f2b5a61842dc659588fdb27fe78b9) FIX/audit into FIX/audit-adcd3, CHANGELOG.md conflict resolved.