### PR TITLE
FIX: audit 10b08 and 0dd9c bundle. ArrayListHasher duplication (10b08) and missing array length validation (0dd9c)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,140 @@
+# 09/06/26 - Audit 10b08 and 0dd9c: ArrayListHasher duplicated and hash length not validated
+
+## Finding 10b08 (verbatim)
+
+ArrayListHasher duplicated between Groth16 and Plonk components
+
+We found two ArrayListHasher implementations with identical behavior: one in src/array_list_hasher.ts and the other in src/kzg/structs.ts.
+
+src/array_list_hasher.ts:
+```
+class ArrayListHasher {
+  static n: number;
+
+  static empty(): Field {
+    const a = new Array(this.n).fill(Field(0n));
+    return Poseidon.hashPacked(Provable.Array(Field, this.n), a);
+  }
+
+  static hash(arr: Array<Field>): Field {
+    return Poseidon.hashPacked(Provable.Array(Field, this.n), arr);
+  }
+
+  static open(
+    lhs: Array<Field>,
+    opening: Array<Fp12>,
+    rhs: Array<Field>
+  ): Field {
+    const opening_hashes: Field[] = opening.map((x) =>
+      Poseidon.hashPacked(Fp12, x)
+    );
+
+    let arr: Field[] = [];
+    arr = arr.concat(lhs);
+    arr = arr.concat(opening_hashes);
+    arr = arr.concat(rhs);
+
+    return this.hash(arr);
+  }
+}
+
+ArrayListHasher.n = ATE_LOOP_COUNT.length;
+```
+
+src/kzg/structs.ts:
+```
+class ArrayListHasher {
+  static n: number;
+
+  static empty(): Field {
+    const a = new Array(this.n).fill(Field(0n));
+    return Poseidon.hashPacked(Provable.Array(Field, ATE_LOOP_COUNT.length), a);
+  }
+
+  static hash(arr: Array<Field>): Field {
+    return Poseidon.hashPacked(
+      Provable.Array(Field, ATE_LOOP_COUNT.length),
+      arr
+    );
+  }
+
+  static open(
+    lhs: Array<Field>,
+    opening: Array<Fp12>,
+    rhs: Array<Field>
+  ): Field {
+    const opening_hashes: Field[] = opening.map((x) =>
+      Poseidon.hashPacked(Fp12, x)
+    );
+
+    let arr: Field[] = [];
+    arr = arr.concat(lhs);
+    arr = arr.concat(opening_hashes);
+    arr = arr.concat(rhs);
+
+    return this.hash(arr);
+  }
+}
+
+ArrayListHasher.n = ATE_LOOP_COUNT.length;
+```
+
+The former is used by the Groth16 component (src/groth) and the latter by the Plonk component (src/plonk). We see no reason to maintain them separately, and recommend consolidating them into a single implementation.
+
+## Response (10b08)
+
+Acknowledged. Both classes are functionally identical. `n` is set to `ATE_LOOP_COUNT.length` on both, so the hardcoded variant in `kzg/structs.ts` produces the same results.
+
+## Finding 0dd9c (verbatim)
+
+`ArrayListHasher::hash` does not validate array length
+
+ArrayListHasher::hash is defined as follows:
+```
+  static hash(arr: Array<Field>): Field {
+    return Poseidon.hashPacked(Provable.Array(Field, this.n), arr);
+  }
+```
+From the code, one might expect that the hash is computed over exactly this.n elements of arr. However, Poseidon::hashPacked consumes the actual length of arr rather than this.n.
+
+Poseidon::hashPacked is defined as:
+```
+  hashPacked<T>(type: WithProvable<Hashable<T>>, value: T) {
+    let input = ProvableType.get(type).toInput(value);
+    let packed = packToFields(input);
+    return Poseidon.hash(packed);
+  },
+```
+Provable.Array(Field, this.n) is a call to provableArray, which returns a provable type object with length = this.n captured in its closure. Most methods on this object, such as check and sizeInFields, use length. However, toInput does not:
+```
+    toInput(array) {
+      if (!('toInput' in type)) {
+        throw Error('circuitArray.toInput: element type has no toInput method');
+      }
+      return array.reduce(
+        (curr, value) => HashInput.append(curr, type.toInput(value)),
+        HashInput.empty
+      );
+    },
+```
+Since hashPacked only calls toInput internally, this.n has no effect on the resulting hash. Therefore, arr.length === this.n should be asserted before calling hashPacked. Given that hashPacked takes a type that includes the expected array length, it would be natural for it to validate that arr matches that length. This could be considered a potential upstream issue in o1js.
+
+## Response (0dd9c)
+
+Acknowledged. The observation about `Provable.Array`'s `toInput` is correct: it iterates the actual array elements via `.reduce()`, ignoring the declared `n`. `hashPacked` calls `toInput` without calling `check()`, so no length validation occurs at the hashing step.
+
+In current usage, the length is structurally enforced at every call site: inside ZkProgram circuits, `lines_hashes` is declared as `Provable.Array(Field, ATE_LOOP_COUNT.length)` in `privateInputs` and `fromFields` reconstructs exactly that many elements before the method body runs; in the witness trackers, the array is constructed as `new Array(ATE_LOOP_COUNT.length).fill(Field(0n))` and modified in-place; in `open()`, the three input arrays are `Provable.Array`-declared with sizes summing to 65. A wrong-length array cannot reach `hash()` through any current call path, and if one side drifted the `assertEquals` between the witness tracker digest and the circuit digest would catch it. The risk is limited to future refactors where a clear error at the assertion point is preferable to a cryptic `Field.assertEquals` failure downstream.
+
+### Commit 1 - Regression test for 0dd9c
+
+- **Regression test** (`src/0dd9c_regression.spec.ts`): added `hash with fewer than n elements must throw`, `hash with more than n elements must throw`, and `hash with exactly n elements must not throw`. The first two tests call `ArrayListHasher.hash()` with arrays of length `n - 1` and `n + 1` respectively and expect an error to be thrown. The third test confirms that an array of exactly `n` elements (65) hashes without error.
+
+Run: `npm run test:jest -- src/0dd9c_regression.spec.ts`
+
+Results:
+
+- Regression tests: 2 fail, 1 pass. The wrong-length arrays do not throw on unpatched code, confirming that `hash()` silently hashes whatever it receives regardless of the declared `n`.
+
 # 02/06/26 - Audit adcd3: Groth16 proof and VK parsers do not validate that piN and icN keys are contiguous
 
 ## Finding (verbatim)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,6 +135,17 @@ Results:
 
 - Regression tests: 2 fail, 1 pass. The wrong-length arrays do not throw on unpatched code, confirming that `hash()` silently hashes whatever it receives regardless of the declared `n`.
 
+### Commit 2 - Fix applied
+
+- **`src/array_list_hasher.ts`**: added `arr.length !== this.n` assertion at the top of `hash()`, throwing with expected and actual lengths if the array size does not match. Since `empty()` and `open()` both route through `hash()`, one assertion covers all three methods.
+- **`src/kzg/structs.ts`**: removed duplicate `ArrayListHasher` class (10b08), replaced with import and re-export from `src/array_list_hasher.ts`. All Plonk imports (`from '../../kzg/structs.js'`) continue working without changes. Unused imports (`Poseidon`, `Provable`, `ATE_LOOP_COUNT`) removed.
+
+Run: `npm run test:jest -- src/0dd9c_regression.spec.ts`
+
+Results:
+
+- Regression tests: 3 pass, 0 fail. `ArrayListHasher.hash()` now rejects wrong-length arrays with a descriptive error.
+
 # 02/06/26 - Audit adcd3: Groth16 proof and VK parsers do not validate that piN and icN keys are contiguous
 
 ## Finding (verbatim)

--- a/src/0dd9c_regression.spec.ts
+++ b/src/0dd9c_regression.spec.ts
@@ -1,0 +1,23 @@
+import { Field } from 'o1js';
+import { ArrayListHasher } from './array_list_hasher.js';
+import { ATE_LOOP_COUNT } from './towers/consts.js';
+
+const N = ATE_LOOP_COUNT.length;
+
+describe('regression_0dd9c_array_list_hasher_length_validation', () => {
+
+  test('hash with fewer than n elements must throw', () => {
+    const short = new Array(N - 1).fill(Field(0n));
+    expect(() => ArrayListHasher.hash(short)).toThrow();
+  });
+
+  test('hash with more than n elements must throw', () => {
+    const long = new Array(N + 1).fill(Field(0n));
+    expect(() => ArrayListHasher.hash(long)).toThrow();
+  });
+
+  test('hash with exactly n elements must not throw', () => {
+    const exact = new Array(N).fill(Field(0n));
+    expect(() => ArrayListHasher.hash(exact)).not.toThrow();
+  });
+});

--- a/src/array_list_hasher.ts
+++ b/src/array_list_hasher.ts
@@ -10,6 +10,11 @@ class ArrayListHasher {
   }
 
   static hash(arr: Array<Field>): Field {
+    if (arr.length !== this.n) {
+      throw new Error(
+        `ArrayListHasher.hash: expected ${this.n} elements, got ${arr.length}`
+      );
+    }
     return Poseidon.hashPacked(Provable.Array(Field, this.n), arr);
   }
 

--- a/src/kzg/structs.ts
+++ b/src/kzg/structs.ts
@@ -1,6 +1,7 @@
-import { Field, Poseidon, Provable, Struct } from 'o1js';
-import { ATE_LOOP_COUNT, Fp12, FrC } from '../towers/index.js';
+import { Field, Struct } from 'o1js';
+import { Fp12, FrC } from '../towers/index.js';
 import { G1Affine } from '../ec/index.js';
+import { ArrayListHasher } from '../array_list_hasher.js';
 
 // e(A, [1])*e(negB, [x]) = 1
 class KzgProof extends Struct({
@@ -36,40 +37,5 @@ class KzgAccumulator extends Struct({
     });
   }
 }
-
-class ArrayListHasher {
-  static n: number;
-
-  static empty(): Field {
-    const a = new Array(this.n).fill(Field(0n));
-    return Poseidon.hashPacked(Provable.Array(Field, ATE_LOOP_COUNT.length), a);
-  }
-
-  static hash(arr: Array<Field>): Field {
-    return Poseidon.hashPacked(
-      Provable.Array(Field, ATE_LOOP_COUNT.length),
-      arr
-    );
-  }
-
-  static open(
-    lhs: Array<Field>,
-    opening: Array<Fp12>,
-    rhs: Array<Field>
-  ): Field {
-    const opening_hashes: Field[] = opening.map((x) =>
-      Poseidon.hashPacked(Fp12, x)
-    );
-
-    let arr: Field[] = [];
-    arr = arr.concat(lhs);
-    arr = arr.concat(opening_hashes);
-    arr = arr.concat(rhs);
-
-    return this.hash(arr);
-  }
-}
-
-ArrayListHasher.n = ATE_LOOP_COUNT.length;
 
 export { KzgProof, KzgState, KzgAccumulator, ArrayListHasher };


### PR DESCRIPTION
Formed of two commits:

- [Commit 1, changelog documenting ArrayListHasher duplication (10b08) and missing array length validation (0dd9c), regression tests verifying hash rejects wrong-length arrays (1 pass 2 fail)](https://github.com/Nori-zk/proof-conversion/commit/f63dce9db2b5d95014bbffd23dad2d5f10f86829)
- [Commit 2, length assertion added to ArrayListHasher.hash() (0dd9c), duplicate ArrayListHasher removed from kzg/structs.ts and replaced with re-export from array_list_hasher.ts (10b08), all regression tests pass (3 pass 0 fail)](https://github.com/Nori-zk/proof-conversion/commit/b4ca3c3e0d6c1bc0d321d6e1f4058c6041e6548c)
