### PR TITLE
FIX: audit af97e, deprecated Gadgets.SHA256 and Hash.SHA2_256

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,70 @@
+# 23/06/26 - Audit af97e: Deprecated API Gadgets.SHA256 is used in the Plonk verifier
+
+## Finding af97e (verbatim)
+
+gammaKzgDigest_part0 and gammaKzgDigest_part1 from src/plonk/fiat-shamir/index.ts use the deprecated API Gadgets.SHA256.
+
+In gammaKzgDigest_part0:
+
+```
+    let H = Gadgets.SHA256.initialState;
+    for (let i = 0; i < 11; i++) {
+      const messageBlock = chunks.slice(16 * i, 16 * (i + 1));
+      let W = Gadgets.SHA256.createMessageSchedule(messageBlock);
+      H = Gadgets.SHA256.compression(H, W);
+    }
+```
+
+And in gammaKzgDigest_part1:
+
+```
+    const messageBlock = chunks;
+    let W = Gadgets.SHA256.createMessageSchedule(messageBlock);
+    H = Gadgets.SHA256.compression(H, W);
+```
+
+We see that Gadgets.SHA256 is used to transfer a SHA256 state from zkp7 to zkp8. Therefore, we recommend to use Gadgets.SHA2 instead of SHA256:
+
+```
+Gadgets.SHA256.initialState -> Gadgets.SHA2.initialState<UInt32>(256)
+Gadgets.SHA256.createMessageSchedule(block) -> Gadgets.SHA2.messageSchedule(256, block)
+Gadgets.SHA256.compression(H, W)   -> Gadgets.SHA2.compression(256, H, W)
+```
+
+## Discussion
+
+### Zellic and Nori
+
+We were aware of this deprecation since February (noted in the CHANGELOG under Outstanding) and discussed it with o1 Labs. Their recommendation was Hash.SHA2_256, but we need the internal functions (initialState, createMessageSchedule, compression) to transfer SHA256 state between zkp7 and zkp8. When we previously attempted the swap to Gadgets.SHA2, we observed unexpected differences in the output and deferred the migration.
+
+### Nori and o1 Labs (2/26)
+
+One task Nori didn't succeed at this release was removing all the Gadget.SHA256 references. The reason being is there is quite a lot of use of internal methods from these primitives: https://github.com/search?q=repo%3ANori-zk%2Fproof-conversion%20Gadgets.SHA256&type=code Could we bother you for some advice about this?
+
+Hash.SHA2_256 only exposes .hash(data) the black box that handles padding, scheduling, and all compression internally. There's no way to hand it a mid-stream H, run one block at a time, or get the initialState out. We still need some method which definitely wont be deprecated in upcoming releases which gives us access to those internals. Gadgets.SHA2 does seem to fit the bill (and we don't see any deprecation warnings) but this contradicts previous advice.
+
+o1 Labs - affirmed they dont plan to do any more deprecations right now, nor for the function in question (Gadgets.SHA2).
+
+### Nori and o1 Labs (1/26)
+
+Nori asked o1 Labs which of the newer SHA2 methods to use for longevity, presuming Gadgets.SHA2.hash(256, piBytes).
+
+o1 Labs (30/01/26): Hash.SHA.. should be used - it's all mostly the same, just the API and clarification around it are a little different
+
+## Response
+
+We agree that the deprecated method should be replaced and were planning on its removal. Based on prior discussions with o1 Labs, Hash.SHA2_256 was a recommended replacement. However it did not expose suitable functionality and while Hash.SHA2_256 is not marked as deprecated, its docstring indicates it is an alias for Gadgets.SHA256.hash which is deprecated. The initial recommendation of Hash.SHA2_256 would not have resolved the deprecation.
+
+## Commit - Fix applied
+
+- **`src/plonk/fiat-shamir/index.ts`**: `Gadgets.SHA256.initialState`, `Gadgets.SHA256.createMessageSchedule`, `Gadgets.SHA256.compression` replaced with `Gadgets.SHA2.initialState<UInt32>(256)`, `Gadgets.SHA2.messageSchedule(256, ...)`, `Gadgets.SHA2.compression(256, ...)`. `Hash.SHA2_256.hash` calls replaced with `Gadgets.SHA2.hash(256, ...)` as `Hash.SHA2_256` aliases the deprecated `Gadgets.SHA256.hash` in its implementation. Unused `Hash` import removed.
+- **`src/plonk/piop/hash_fr.ts`**: `Hash.SHA2_256.hash` calls replaced with `Gadgets.SHA2.hash(256, ...)` for the same reason. Unused `Hash` import removed.
+- **`src/plonk/parse_pi.ts`**: deprecated comment and commented-out `Gadgets.SHA256.hash` call removed.
+- **`src/blobstream/batcher.ts`**: `Gadgets.SHA256.initialState`, `Gadgets.SHA256.createMessageSchedule`, `Gadgets.SHA256.compression` replaced with `Gadgets.SHA2` equivalents.
+- **`src/sha/sha_hash.ts`**: `Gadgets.SHA256.hash`, `Gadgets.SHA256.initialState`, `Gadgets.SHA256.createMessageSchedule`, `Gadgets.SHA256.compression` replaced with `Gadgets.SHA2` equivalents.
+
+---
+
 # 23/06/26 - Audit e68c5: G2Line.evaluate_g1 is dead code and does not implement the correct evaluation of the line function on G1
 
 ## Finding e68c5 (verbatim)

--- a/src/blobstream/batcher.ts
+++ b/src/blobstream/batcher.ts
@@ -228,7 +228,7 @@ const batcherVerifier = ZkProgram({
           chunks.push(chunk);
         }
 
-        let initialStateFields = hashToFields(Gadgets.SHA256.initialState);
+        let initialStateFields = hashToFields(Gadgets.SHA2.initialState<UInt32>(256));
         const currentH = Provable.if(
           isFirst,
           Provable.Array(Field, 2),
@@ -236,9 +236,9 @@ const batcherVerifier = ZkProgram({
           input.currentRollingHash
         );
 
-        let W = Gadgets.SHA256.createMessageSchedule(chunks);
+        let W = Gadgets.SHA2.messageSchedule(256, chunks);
         let H = fieldsToHash(currentH);
-        H = Gadgets.SHA256.compression(H, W);
+        H = Gadgets.SHA2.compression(256, H, W);
 
         const numToAdd = bytesToField(incrementByBytes.bytes.slice(0, 20));
         // Provable.asProver(() => {

--- a/src/plonk/fiat-shamir/index.ts
+++ b/src/plonk/fiat-shamir/index.ts
@@ -1,6 +1,6 @@
 import { Bytes, Gadgets, UInt8, UInt32 } from 'o1js';
 import { FrC } from '../../towers/index.js';
-import { Hash, Struct } from 'o1js';
+import { Struct } from 'o1js';
 import { FpC } from '../../towers/index.js';
 import { Sp1PlonkProof } from '../proof.js';
 import {
@@ -294,7 +294,7 @@ class Sp1PlonkFiatShamir extends Struct({
     cm_bytes = cm_bytes.concat(oy);
 
     // assert(cm_bytes.length === gammaSizeInBytes());
-    this.gamma_digest = Hash.SHA2_256.hash(new BytesGamma(cm_bytes));
+    this.gamma_digest = Gadgets.SHA2.hash(256, new BytesGamma(cm_bytes));
     this.gamma = shaToFr(this.gamma_digest);
   }
 
@@ -307,7 +307,7 @@ class Sp1PlonkFiatShamir extends Struct({
 
     cm_bytes = cm_bytes.concat(this.gamma_digest.bytes);
     // assert(cm_bytes.length === sizeBetaBytes())
-    this.beta_digest = Hash.SHA2_256.hash(new BytesBeta(cm_bytes));
+    this.beta_digest = Gadgets.SHA2.hash(256, new BytesBeta(cm_bytes));
     this.beta = shaToFr(this.beta_digest);
   }
 
@@ -337,7 +337,7 @@ class Sp1PlonkFiatShamir extends Struct({
     );
     cm_bytes = cm_bytes.concat(grand_product_y);
 
-    this.alpha_digest = Hash.SHA2_256.hash(new BytesAlpha(cm_bytes));
+    this.alpha_digest = Gadgets.SHA2.hash(256, new BytesAlpha(cm_bytes));
     this.alpha = shaToFr(this.alpha_digest);
   }
 
@@ -369,7 +369,7 @@ class Sp1PlonkFiatShamir extends Struct({
     const h2_y = provableBn254BaseFieldToBytes(proof.h2_y);
     cm_bytes = cm_bytes.concat(h2_y);
 
-    this.zeta_digest = Hash.SHA2_256.hash(new BytesZeta(cm_bytes));
+    this.zeta_digest = Gadgets.SHA2.hash(256, new BytesZeta(cm_bytes));
     this.zeta = shaToFr(this.zeta_digest);
   }
 
@@ -433,7 +433,7 @@ class Sp1PlonkFiatShamir extends Struct({
       provableBn254ScalarFieldToBytes(proof.grand_product_at_omega_zeta)
     );
 
-    this.gamma_kzg_digest = Hash.SHA2_256.hash(new BytesGammaKzg(cm_bytes));
+    this.gamma_kzg_digest = Gadgets.SHA2.hash(256, new BytesGammaKzg(cm_bytes));
     this.gamma_kzg = shaToFr(this.gamma_kzg_digest);
   }
 
@@ -463,7 +463,7 @@ class Sp1PlonkFiatShamir extends Struct({
     cm_bytes = cm_bytes.concat(provableBn254ScalarFieldToBytes(this.zeta));
     cm_bytes = cm_bytes.concat(provableBn254ScalarFieldToBytes(this.gamma_kzg));
 
-    const random_digest = Hash.SHA2_256.hash(new BytesRandomKzg(cm_bytes));
+    const random_digest = Gadgets.SHA2.hash(256, new BytesRandomKzg(cm_bytes));
     return shaToFr(random_digest);
   }
 
@@ -534,16 +534,16 @@ class Sp1PlonkFiatShamir extends Struct({
       chunks.push(chunk);
     }
 
-    let H = Gadgets.SHA256.initialState;
+    let H = Gadgets.SHA2.initialState<UInt32>(256);
     for (let i = 0; i < 11; i++) {
       const messageBlock = chunks.slice(16 * i, 16 * (i + 1));
-      let W = Gadgets.SHA256.createMessageSchedule(messageBlock);
-      H = Gadgets.SHA256.compression(H, W);
+      let W = Gadgets.SHA2.messageSchedule(256, messageBlock);
+      H = Gadgets.SHA2.compression(256, H, W);
     }
 
     return H;
 
-    // this.gamma_kzg_digest = Hash.SHA2_256.hash(new BytesGammaKzg(cm_bytes));
+    // this.gamma_kzg_digest = Gadgets.SHA2.hash(256, new BytesGammaKzg(cm_bytes));
   }
 
   gammaKzgDigest_part1(proof: Sp1PlonkProof, H: UInt32[]) {
@@ -566,8 +566,8 @@ class Sp1PlonkFiatShamir extends Struct({
     }
 
     const messageBlock = chunks;
-    let W = Gadgets.SHA256.createMessageSchedule(messageBlock);
-    H = Gadgets.SHA256.compression(H, W);
+    let W = Gadgets.SHA2.messageSchedule(256, messageBlock);
+    H = Gadgets.SHA2.compression(256, H, W);
 
     this.gamma_kzg_digest = Bytes.from(
       H.map((x) => wordToBytes(x.value, 4).reverse()).flat()

--- a/src/plonk/parse_pi.ts
+++ b/src/plonk/parse_pi.ts
@@ -42,11 +42,6 @@ export function parseDigestProvable(digest: Bytes): FrC {
 }
 
 export function parsePublicInputsProvable(piBytes: Bytes): FrC {
-  // CHECKME!
-  // Old method had deprecation warning: @deprecated {@link SHA256} is deprecated in favor of {@link SHA2}
-  //const digest = Gadgets.SHA256.hash(piBytes);
-
-  const digest = Gadgets.SHA2.hash(256, piBytes); // This is mentioned in the deprecation warning
-  
+  const digest = Gadgets.SHA2.hash(256, piBytes);
   return parseDigestProvable(digest);
 }

--- a/src/plonk/piop/hash_fr.ts
+++ b/src/plonk/piop/hash_fr.ts
@@ -1,4 +1,4 @@
-import { Bool, Bytes, Gadgets, Hash, Provable, Struct, UInt8 } from 'o1js';
+import { Bool, Bytes, Gadgets, Provable, Struct, UInt8 } from 'o1js';
 import { FpC, FrC, FrU } from '../../towers/index.js';
 import { provableBn254BaseFieldToBytes } from '../../sha/utils.js';
 
@@ -142,7 +142,7 @@ class HashFr extends Struct({
 
     bytes = bytes.concat(this.HASH_FR_SIZE_DOMAIN.bytes);
 
-    const b0 = Hash.SHA2_256.hash(new BytesB0(bytes));
+    const b0 = Gadgets.SHA2.hash(256, new BytesB0(bytes));
 
     // reset
     bytes = [];
@@ -153,7 +153,7 @@ class HashFr extends Struct({
 
     bytes = bytes.concat(this.HASH_FR_SIZE_DOMAIN.bytes);
 
-    const b1 = Hash.SHA2_256.hash(new BytesB1(bytes));
+    const b1 = Gadgets.SHA2.hash(256, new BytesB1(bytes));
 
     // reset again
     bytes = xorShaOutputs(b0, b1);
@@ -163,7 +163,7 @@ class HashFr extends Struct({
 
     bytes = bytes.concat(this.HASH_FR_SIZE_DOMAIN.bytes);
 
-    const b2 = Hash.SHA2_256.hash(new BytesB2(bytes));
+    const b2 = Gadgets.SHA2.hash(256, new BytesB2(bytes));
 
     let res = shl_123_modR(b1);
     const low = shr128(b2);

--- a/src/sha/sha_hash.ts
+++ b/src/sha/sha_hash.ts
@@ -50,7 +50,7 @@ let s = 'a'.repeat(741);
 
 class Bytes741 extends Bytes(741) {}
 let preimageBytes = Bytes741.fromString(s);
-let hash = Gadgets.SHA256.hash(preimageBytes);
+let hash = Gadgets.SHA2.hash(256, preimageBytes);
 console.log(hash.toHex());
 //96505839157e4f0984258b89bda90c3661bfce8505d34120f2989236f4c576a2
 
@@ -79,7 +79,7 @@ function wordToBytes(word: Field, bytesPerWord = 8): UInt8[] {
 
 const chunks: UInt32[] = [];
 
-let H = Gadgets.SHA256.initialState;
+let H = Gadgets.SHA2.initialState<UInt32>(256);
 
 for (let i = 0; i < preimage.length; i += 4) {
   const chunk = UInt32.Unsafe.fromField(
@@ -92,8 +92,8 @@ const n = 12;
 
 for (let i = 0; i < n; i++) {
   const messageBlock = chunks.slice(16 * i, 16 * (i + 1));
-  let W = Gadgets.SHA256.createMessageSchedule(messageBlock);
-  H = Gadgets.SHA256.compression(H, W);
+  let W = Gadgets.SHA2.messageSchedule(256, messageBlock);
+  H = Gadgets.SHA2.compression(256, H, W);
 }
 
 const digest_bytes = Bytes.from(


### PR DESCRIPTION
Replaced with Gadgets.SHA2 across all call sites (fiat-shamir, hash_fr, batcher, sha_hash, parse_pi), unused Hash imports removed, changelog updated