### PR TITLE
FIX: audit 1a697 and a9dea - remove dead code and add comment (no toBigInt changes)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,70 @@
+# 23/06/26 - Audit af97e: Deprecated API Gadgets.SHA256 is used in the Plonk verifier
+
+## Finding af97e (verbatim)
+
+gammaKzgDigest_part0 and gammaKzgDigest_part1 from src/plonk/fiat-shamir/index.ts use the deprecated API Gadgets.SHA256.
+
+In gammaKzgDigest_part0:
+
+```
+    let H = Gadgets.SHA256.initialState;
+    for (let i = 0; i < 11; i++) {
+      const messageBlock = chunks.slice(16 * i, 16 * (i + 1));
+      let W = Gadgets.SHA256.createMessageSchedule(messageBlock);
+      H = Gadgets.SHA256.compression(H, W);
+    }
+```
+
+And in gammaKzgDigest_part1:
+
+```
+    const messageBlock = chunks;
+    let W = Gadgets.SHA256.createMessageSchedule(messageBlock);
+    H = Gadgets.SHA256.compression(H, W);
+```
+
+We see that Gadgets.SHA256 is used to transfer a SHA256 state from zkp7 to zkp8. Therefore, we recommend to use Gadgets.SHA2 instead of SHA256:
+
+```
+Gadgets.SHA256.initialState -> Gadgets.SHA2.initialState<UInt32>(256)
+Gadgets.SHA256.createMessageSchedule(block) -> Gadgets.SHA2.messageSchedule(256, block)
+Gadgets.SHA256.compression(H, W)   -> Gadgets.SHA2.compression(256, H, W)
+```
+
+## Discussion
+
+### Zellic and Nori
+
+We were aware of this deprecation since February (noted in the CHANGELOG under Outstanding) and discussed it with o1 Labs. Their recommendation was Hash.SHA2_256, but we need the internal functions (initialState, createMessageSchedule, compression) to transfer SHA256 state between zkp7 and zkp8. When we previously attempted the swap to Gadgets.SHA2, we observed unexpected differences in the output and deferred the migration.
+
+### Nori and o1 Labs (2/26)
+
+One task Nori didn't succeed at this release was removing all the Gadget.SHA256 references. The reason being is there is quite a lot of use of internal methods from these primitives: https://github.com/search?q=repo%3ANori-zk%2Fproof-conversion%20Gadgets.SHA256&type=code Could we bother you for some advice about this?
+
+Hash.SHA2_256 only exposes .hash(data) the black box that handles padding, scheduling, and all compression internally. There's no way to hand it a mid-stream H, run one block at a time, or get the initialState out. We still need some method which definitely wont be deprecated in upcoming releases which gives us access to those internals. Gadgets.SHA2 does seem to fit the bill (and we don't see any deprecation warnings) but this contradicts previous advice.
+
+o1 Labs - affirmed they dont plan to do any more deprecations right now, nor for the function in question (Gadgets.SHA2).
+
+### Nori and o1 Labs (1/26)
+
+Nori asked o1 Labs which of the newer SHA2 methods to use for longevity, presuming Gadgets.SHA2.hash(256, piBytes).
+
+o1 Labs (30/01/26): Hash.SHA.. should be used - it's all mostly the same, just the API and clarification around it are a little different
+
+## Response
+
+We agree that the deprecated method should be replaced and were planning on its removal. Based on prior discussions with o1 Labs, Hash.SHA2_256 was a recommended replacement. However it did not expose suitable functionality and while Hash.SHA2_256 is not marked as deprecated, its docstring indicates it is an alias for Gadgets.SHA256.hash which is deprecated. The initial recommendation of Hash.SHA2_256 would not have resolved the deprecation.
+
+## Commit - Fix applied
+
+- **`src/plonk/fiat-shamir/index.ts`**: `Gadgets.SHA256.initialState`, `Gadgets.SHA256.createMessageSchedule`, `Gadgets.SHA256.compression` replaced with `Gadgets.SHA2.initialState<UInt32>(256)`, `Gadgets.SHA2.messageSchedule(256, ...)`, `Gadgets.SHA2.compression(256, ...)`. `Hash.SHA2_256.hash` calls replaced with `Gadgets.SHA2.hash(256, ...)` as `Hash.SHA2_256` aliases the deprecated `Gadgets.SHA256.hash` in its implementation. Unused `Hash` import removed.
+- **`src/plonk/piop/hash_fr.ts`**: `Hash.SHA2_256.hash` calls replaced with `Gadgets.SHA2.hash(256, ...)` for the same reason. Unused `Hash` import removed.
+- **`src/plonk/parse_pi.ts`**: deprecated comment and commented-out `Gadgets.SHA256.hash` call removed.
+- **`src/blobstream/batcher.ts`**: `Gadgets.SHA256.initialState`, `Gadgets.SHA256.createMessageSchedule`, `Gadgets.SHA256.compression` replaced with `Gadgets.SHA2` equivalents.
+- **`src/sha/sha_hash.ts`**: `Gadgets.SHA256.hash`, `Gadgets.SHA256.initialState`, `Gadgets.SHA256.createMessageSchedule`, `Gadgets.SHA256.compression` replaced with `Gadgets.SHA2` equivalents.
+
+---
+
 # 23/06/26 - Audit e68c5: G2Line.evaluate_g1 is dead code and does not implement the correct evaluation of the line function on G1
 
 ## Finding e68c5 (verbatim)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,128 @@
+# 02/07/26 - Audit 1a697 and a9dea: Field.toBigInt debug-only usage and undocumented value-dependence
+
+## Finding 1a697 (verbatim)
+
+`Field.toBigInt` is a debug-only o1js operation but is used outside debug contexts
+
+The o1js Field.toBigInt method is documented in the library as a debug-only operation. Its docstring (o1js/src/lib/provable/field.ts:155) states:
+
+> Warning: This operation does _not_ affect the circuit and can't be used to prove anything about the bigint representation of the {@link Field}. Use the operation only during debugging.
+
+The audited code ultimately does not call this function for circuit creation.
+But the calling functions do create circuits (which are then not used) and do not document that they rely on toBigInt usage internally.
+
+The calling functions are used for proof creation, which is a non-debug usage, in the following places:
+
+Inside the `Provable.witness` callback, with the result constrained back in-circuit
+
+- src/sha/sha_hash.ts:68 (wordToBytes, with bytesToWord(bytes).assertEquals(word))
+- src/sha/utils.ts:43 (wordToBytes, with bytesToWord(bytes).assertEquals(word))
+- src/towers/fp2.ts:104,105 (Fp2.mul, with assertMul(...) over the witnessed cross term)
+- src/towers/fp2.ts:124 (Fp2.square, with two assertMul(...) constraints over the witnessed coefficients)
+
+Off-circuit witness generation, proof parsing, accumulator cloning
+
+- src/groth/compute_pi.ts:25 -- pis[i].toBigInt() !== 0n gates an icPoint.scale(pis[i]) call to avoid o1js' "scale by zero" assertion. Called from src/groth/proof.ts:101 (in createProofClass, reached via parseProof), outside any circuit.
+- src/groth/witness_tracker.ts:343 -- the same zero guard, in the off-circuit witness tracker (WitnessTracker).
+- src/ec/g2.ts:43 -- G2Affine.add, branches on eq.toBigInt() === 1n to choose between computeLambdaSame and computeLambdaDiff. G2Affine.add is dead code in the audited code (no callers).
+- src/lines/index.ts:28 -- G2Line.fromPoints, same branch on eq.toBigInt(). Called from src/lines/coeffs.ts:13,18,23,33,38 (computeLineCoeffs), which is in turn called only from src/groth/proof.ts:112, src/groth/vk.ts:44,45, src/groth/witness_tracker.ts:42, and src/plonk/mm_loop/precompute_lines.ts:25,45 -- all off-circuit.
+- src/plonk/state.ts:47-78 -- 22 calls inside Sp1PlonkState.deepClone(), reached only via src/plonk/accumulator.ts:17 (Sp1PlonkAccumulator.deepClone()), which is itself called only from the off-circuit src/plonk/recursion/witness_tracker.ts.
+- src/plonk/fiat-shamir/index.ts:194,196,198,200,202 -- 5 calls inside Sp1PlonkFiatShamir.deepClone(), reached via the same off-circuit path.
+- src/kzg/structs.ts:23 -- KzgState.deepClone(), reached via KzgAccumulator.deepClone() from src/plonk/recursion/witness_tracker.ts:337,338,....
+
+### Impact
+
+No current soundness or completeness impact has been identified in the audited code.
+With the current implementation of toBigInt, using it during circuit creation on a non-constant value would throw an error and therefore be noticed.
+
+However, using a library function that is marked as debug-only for production code bears risks.
+Its implementation could change in the future: the library could alter the behaviour in a way that goes unnoticed but breaks proof generation.
+The correctness of a debug-only function is likely a low priority for library maintainers and changes could be made with no security risk assessment.
+
+### Recommendations
+
+Avoid converting bigint values to Field values and then converting them back via toBigInt.
+Use the original bigint values instead.
+
+## Finding a9dea (verbatim)
+
+Undocumented value-dependence for circuit-generating functions
+
+The audited code has helper functions that take a parameter whose type is a circuit value, but whose value selects between alternative subroutines via a JS-level if, and whose body invokes o1js operations in each branch.
+The function signature strongly suggests that the function is usable for circuit generation for a variable value of that parameter, which is not the case.
+
+If such a helper is called from inside a ZkProgram method (or from any other tracing context), the constraints it contributes depend on the value of the parameter at that exact call: the helper specializes the circuit to one specific value of the parameter, and the resulting circuit only verifies the computation for that one value. None of these helpers carry documentation reflecting this restriction.
+
+We found the following instances of this undocumented pattern.
+
+`G2Affine.add(rhs)` (`src/ec/g2.ts:39`).
+
+The body computes
+
+```
+const eq = this.equals(rhs);
+let lambda;
+if (eq.toBigInt() === 1n) {
+  lambda = this.computeLambdaSame();
+} else {
+  lambda = this.computeLambdaDiff(rhs);
+}
+```
+
+The branch is taken based on the bigint value of an o1js Field (via toBigInt, which throws outside a constant/prover context anyway -- see [#FindingToBigIntDebugOnly]), so this helper cannot be called from a circuit method without also breaking that contract. It has no callers in the audited code.
+
+`G2Line.fromPoints(lhs, rhs)` (`src/lines/index.ts:24`).
+Same if (eq.toBigInt() === 1n) shape, selecting between computeLambdaSame and computeLambdaDiff.
+Called transitively only from computeLineCoeffs, which itself is only invoked off-circuit (parseProof, GrothVk setup, WitnessTracker, precompute_lines).
+
+### Impact
+
+There is no impact in the audited code as all callees do not expect the functions to implement in-circuit branching.
+Additionally, all cases are combined with a call to toBigInt, which, in its implementation in the used library version, would throw on a non-constant value.
+
+### Recommendations
+
+For each of the functions, add a one-line code comment at the function definition stating that the function's branch structure is resolved at circuit-construction time.
+
+Add an explicit throw if a non-constant value is supplied to the argument that the branching depends on to not rely on the behaviour of the debug-only toBigInt function.
+
+## Discussion
+
+### Nori and Zellic
+
+Just with regards to 1a697 and a9dea. We discussed with o1 labs about the use of .toBigInt() and have been assured there is no problem with using it. That being said happy to remove the dead code / adding the comment.
+
+### Nori and o1 Labs (6/24/26)
+
+Nori: We have an audit finding 1a697: "Field.toBigInt is a debug-only o1js operation but is used outside debug contexts", which is largely driven by the warning in the Field.toBigInt() docstring: "Warning: This operation does not affect the circuit and can't be used to prove anything about the bigint representation of the Field. Use the operation only during debugging." This function is used extensively in proof conversion both inside witnesses (e.g. https://github.com/Nori-zk/proof-conversion/blob/develop/src/sha/utils.ts#L43) where the result is constrained back in circuit via assertEquals, and off circuit in places like deepClone methods and witness trackers for extracting values from Field types. The witness pattern itself follows the standard approach (https://docs.o1labs.org/o1js/writing-constraint-systems/witnesses) of computing off circuit and constraining the output, but the question is whether Field.toBigInt() is safe to use for production code or if it is genuinely debug only. We also note that ForeignField.toBigInt() does not carry the same warning, so it seems a little inconsistent in the api and wanted to get your impression of it.
+
+o1 Labs: .toBigint() is fine to use within a witness blocks and anywhere that's not in provable code for production systems. If you use it in witness blocks, make sure that, as you said, you constraint the witnessed value properly but there's no concern of doing is that way.
+
+## Response
+
+Every use of `Field.toBigInt()` in proof-conversion is idiomatic and correctly constrained. Inside `Provable.witness` callbacks the extracted value is constrained back in-circuit via `assertEquals`, `assertMul`, etc. All remaining call sites are off-circuit (deepClone, witness trackers, proof parsing). This follows the standard witness pattern documented by o1 Labs at https://docs.o1labs.org/o1js/writing-constraint-systems/witnesses.
+
+As confirmed by o1 Labs in the discussion above, `Field.toBigInt()` is fine to use in witness blocks and off-circuit code for production systems.
+
+The "debug-only" warning in the `Field.toBigInt()` docstring is heavy-handed. o1js itself enforces the safety boundary at compile time, calling `Field.toBigInt()` on a variable inside a ZkProgram method throws:
+
+```
+Error: x.toBigInt() was called on a variable field element `x` in provable code.
+This is not supported, because variables represent an abstract computation,
+which only carries actual values during proving, but not during compiling.
+```
+
+It is not possible to misuse `Field.toBigInt()` inside provable code; the library prevents it. We also note that `ForeignField.toBigInt()` does not carry any such warning, its docstring is simply "Convert this field element to a bigint" - which further suggests the warning is an inconsistency in the o1js API documentation rather than a genuine safety boundary.
+
+We accept the recommendation to remove dead code and add comments where appropriate.
+
+### Commit - Fix applied
+
+- **`src/ec/g2.ts`**: removed dead code `G2Affine.add` method (1a697/a9dea).
+- **`src/lines/index.ts`**: added comment to `G2Line.fromPoints` documenting that the `eq.toBigInt()` branch is resolved at JS level and is off-circuit only (a9dea).
+
+---
+
 # 23/06/26 - Audit af97e: Deprecated API Gadgets.SHA256 is used in the Plonk verifier
 
 ## Finding af97e (verbatim)

--- a/src/blobstream/batcher.ts
+++ b/src/blobstream/batcher.ts
@@ -228,7 +228,7 @@ const batcherVerifier = ZkProgram({
           chunks.push(chunk);
         }
 
-        let initialStateFields = hashToFields(Gadgets.SHA256.initialState);
+        let initialStateFields = hashToFields(Gadgets.SHA2.initialState<UInt32>(256));
         const currentH = Provable.if(
           isFirst,
           Provable.Array(Field, 2),
@@ -236,9 +236,9 @@ const batcherVerifier = ZkProgram({
           input.currentRollingHash
         );
 
-        let W = Gadgets.SHA256.createMessageSchedule(chunks);
+        let W = Gadgets.SHA2.messageSchedule(256, chunks);
         let H = fieldsToHash(currentH);
-        H = Gadgets.SHA256.compression(H, W);
+        H = Gadgets.SHA2.compression(256, H, W);
 
         const numToAdd = bytesToField(incrementByBytes.bytes.slice(0, 20));
         // Provable.asProver(() => {

--- a/src/ec/g2.ts
+++ b/src/ec/g2.ts
@@ -35,23 +35,6 @@ class G2Affine extends Struct({ x: Fp2, y: Fp2 }) {
     return this.y.sub(this.x.mul(lambda));
   }
 
-  // assumes that this and rhs are not 0 points
-  add(rhs: G2Affine): G2Affine {
-    const eq = this.equals(rhs);
-
-    let lambda;
-    if (eq.toBigInt() === 1n) {
-      lambda = this.computeLambdaSame();
-    } else {
-      lambda = this.computeLambdaDiff(rhs);
-    }
-
-    const x_3 = lambda.square().sub(this.x).sub(rhs.x);
-    const y_3 = lambda.mul(this.x.sub(x_3)).sub(this.y);
-
-    return new G2Affine({ x: x_3, y: y_3 });
-  }
-
   double_from_line(lambda: Fp2) {
     const x_3 = lambda.square().sub(this.x).sub(this.x); // x_3 = λ^2 - 2x_1
     const y_3 = lambda.mul(this.x.sub(x_3)).sub(this.y); // y_3 = λ(x_1 - x_3) - y_1

--- a/src/lines/index.ts
+++ b/src/lines/index.ts
@@ -21,6 +21,10 @@ class G2Line extends Struct({ lambda: Fp2, neg_mu: Fp2 }) {
     return new G2Line(value.lambda, value.neg_mu);
   }
 
+  // [a9dea] Off-circuit only. The eq.toBigInt() branch selects between computeLambdaSame
+  // and computeLambdaDiff at JS level, specializing to one code path. Calling this inside
+  // a ZkProgram method would fix the circuit to whichever branch runs during compilation.
+  // toBigInt() on a variable Field throws at compile time, preventing accidental misuse.
   static fromPoints(lhs: G2Affine, rhs: G2Affine): G2Line {
     const eq = lhs.equals(rhs);
 

--- a/src/plonk/fiat-shamir/index.ts
+++ b/src/plonk/fiat-shamir/index.ts
@@ -1,6 +1,6 @@
 import { Bytes, Gadgets, UInt8, UInt32 } from 'o1js';
 import { FrC } from '../../towers/index.js';
-import { Hash, Struct } from 'o1js';
+import { Struct } from 'o1js';
 import { FpC } from '../../towers/index.js';
 import { Sp1PlonkProof } from '../proof.js';
 import {
@@ -294,7 +294,7 @@ class Sp1PlonkFiatShamir extends Struct({
     cm_bytes = cm_bytes.concat(oy);
 
     // assert(cm_bytes.length === gammaSizeInBytes());
-    this.gamma_digest = Hash.SHA2_256.hash(new BytesGamma(cm_bytes));
+    this.gamma_digest = Gadgets.SHA2.hash(256, new BytesGamma(cm_bytes));
     this.gamma = shaToFr(this.gamma_digest);
   }
 
@@ -307,7 +307,7 @@ class Sp1PlonkFiatShamir extends Struct({
 
     cm_bytes = cm_bytes.concat(this.gamma_digest.bytes);
     // assert(cm_bytes.length === sizeBetaBytes())
-    this.beta_digest = Hash.SHA2_256.hash(new BytesBeta(cm_bytes));
+    this.beta_digest = Gadgets.SHA2.hash(256, new BytesBeta(cm_bytes));
     this.beta = shaToFr(this.beta_digest);
   }
 
@@ -337,7 +337,7 @@ class Sp1PlonkFiatShamir extends Struct({
     );
     cm_bytes = cm_bytes.concat(grand_product_y);
 
-    this.alpha_digest = Hash.SHA2_256.hash(new BytesAlpha(cm_bytes));
+    this.alpha_digest = Gadgets.SHA2.hash(256, new BytesAlpha(cm_bytes));
     this.alpha = shaToFr(this.alpha_digest);
   }
 
@@ -369,7 +369,7 @@ class Sp1PlonkFiatShamir extends Struct({
     const h2_y = provableBn254BaseFieldToBytes(proof.h2_y);
     cm_bytes = cm_bytes.concat(h2_y);
 
-    this.zeta_digest = Hash.SHA2_256.hash(new BytesZeta(cm_bytes));
+    this.zeta_digest = Gadgets.SHA2.hash(256, new BytesZeta(cm_bytes));
     this.zeta = shaToFr(this.zeta_digest);
   }
 
@@ -433,7 +433,7 @@ class Sp1PlonkFiatShamir extends Struct({
       provableBn254ScalarFieldToBytes(proof.grand_product_at_omega_zeta)
     );
 
-    this.gamma_kzg_digest = Hash.SHA2_256.hash(new BytesGammaKzg(cm_bytes));
+    this.gamma_kzg_digest = Gadgets.SHA2.hash(256, new BytesGammaKzg(cm_bytes));
     this.gamma_kzg = shaToFr(this.gamma_kzg_digest);
   }
 
@@ -463,7 +463,7 @@ class Sp1PlonkFiatShamir extends Struct({
     cm_bytes = cm_bytes.concat(provableBn254ScalarFieldToBytes(this.zeta));
     cm_bytes = cm_bytes.concat(provableBn254ScalarFieldToBytes(this.gamma_kzg));
 
-    const random_digest = Hash.SHA2_256.hash(new BytesRandomKzg(cm_bytes));
+    const random_digest = Gadgets.SHA2.hash(256, new BytesRandomKzg(cm_bytes));
     return shaToFr(random_digest);
   }
 
@@ -534,16 +534,16 @@ class Sp1PlonkFiatShamir extends Struct({
       chunks.push(chunk);
     }
 
-    let H = Gadgets.SHA256.initialState;
+    let H = Gadgets.SHA2.initialState<UInt32>(256);
     for (let i = 0; i < 11; i++) {
       const messageBlock = chunks.slice(16 * i, 16 * (i + 1));
-      let W = Gadgets.SHA256.createMessageSchedule(messageBlock);
-      H = Gadgets.SHA256.compression(H, W);
+      let W = Gadgets.SHA2.messageSchedule(256, messageBlock);
+      H = Gadgets.SHA2.compression(256, H, W);
     }
 
     return H;
 
-    // this.gamma_kzg_digest = Hash.SHA2_256.hash(new BytesGammaKzg(cm_bytes));
+    // this.gamma_kzg_digest = Gadgets.SHA2.hash(256, new BytesGammaKzg(cm_bytes));
   }
 
   gammaKzgDigest_part1(proof: Sp1PlonkProof, H: UInt32[]) {
@@ -566,8 +566,8 @@ class Sp1PlonkFiatShamir extends Struct({
     }
 
     const messageBlock = chunks;
-    let W = Gadgets.SHA256.createMessageSchedule(messageBlock);
-    H = Gadgets.SHA256.compression(H, W);
+    let W = Gadgets.SHA2.messageSchedule(256, messageBlock);
+    H = Gadgets.SHA2.compression(256, H, W);
 
     this.gamma_kzg_digest = Bytes.from(
       H.map((x) => wordToBytes(x.value, 4).reverse()).flat()

--- a/src/plonk/parse_pi.ts
+++ b/src/plonk/parse_pi.ts
@@ -42,11 +42,6 @@ export function parseDigestProvable(digest: Bytes): FrC {
 }
 
 export function parsePublicInputsProvable(piBytes: Bytes): FrC {
-  // CHECKME!
-  // Old method had deprecation warning: @deprecated {@link SHA256} is deprecated in favor of {@link SHA2}
-  //const digest = Gadgets.SHA256.hash(piBytes);
-
-  const digest = Gadgets.SHA2.hash(256, piBytes); // This is mentioned in the deprecation warning
-  
+  const digest = Gadgets.SHA2.hash(256, piBytes);
   return parseDigestProvable(digest);
 }

--- a/src/plonk/piop/hash_fr.ts
+++ b/src/plonk/piop/hash_fr.ts
@@ -1,4 +1,4 @@
-import { Bool, Bytes, Gadgets, Hash, Provable, Struct, UInt8 } from 'o1js';
+import { Bool, Bytes, Gadgets, Provable, Struct, UInt8 } from 'o1js';
 import { FpC, FrC, FrU } from '../../towers/index.js';
 import { provableBn254BaseFieldToBytes } from '../../sha/utils.js';
 
@@ -142,7 +142,7 @@ class HashFr extends Struct({
 
     bytes = bytes.concat(this.HASH_FR_SIZE_DOMAIN.bytes);
 
-    const b0 = Hash.SHA2_256.hash(new BytesB0(bytes));
+    const b0 = Gadgets.SHA2.hash(256, new BytesB0(bytes));
 
     // reset
     bytes = [];
@@ -153,7 +153,7 @@ class HashFr extends Struct({
 
     bytes = bytes.concat(this.HASH_FR_SIZE_DOMAIN.bytes);
 
-    const b1 = Hash.SHA2_256.hash(new BytesB1(bytes));
+    const b1 = Gadgets.SHA2.hash(256, new BytesB1(bytes));
 
     // reset again
     bytes = xorShaOutputs(b0, b1);
@@ -163,7 +163,7 @@ class HashFr extends Struct({
 
     bytes = bytes.concat(this.HASH_FR_SIZE_DOMAIN.bytes);
 
-    const b2 = Hash.SHA2_256.hash(new BytesB2(bytes));
+    const b2 = Gadgets.SHA2.hash(256, new BytesB2(bytes));
 
     let res = shl_123_modR(b1);
     const low = shr128(b2);

--- a/src/sha/sha_hash.ts
+++ b/src/sha/sha_hash.ts
@@ -50,7 +50,7 @@ let s = 'a'.repeat(741);
 
 class Bytes741 extends Bytes(741) {}
 let preimageBytes = Bytes741.fromString(s);
-let hash = Gadgets.SHA256.hash(preimageBytes);
+let hash = Gadgets.SHA2.hash(256, preimageBytes);
 console.log(hash.toHex());
 //96505839157e4f0984258b89bda90c3661bfce8505d34120f2989236f4c576a2
 
@@ -79,7 +79,7 @@ function wordToBytes(word: Field, bytesPerWord = 8): UInt8[] {
 
 const chunks: UInt32[] = [];
 
-let H = Gadgets.SHA256.initialState;
+let H = Gadgets.SHA2.initialState<UInt32>(256);
 
 for (let i = 0; i < preimage.length; i += 4) {
   const chunk = UInt32.Unsafe.fromField(
@@ -92,8 +92,8 @@ const n = 12;
 
 for (let i = 0; i < n; i++) {
   const messageBlock = chunks.slice(16 * i, 16 * (i + 1));
-  let W = Gadgets.SHA256.createMessageSchedule(messageBlock);
-  H = Gadgets.SHA256.compression(H, W);
+  let W = Gadgets.SHA2.messageSchedule(256, messageBlock);
+  H = Gadgets.SHA2.compression(256, H, W);
 }
 
 const digest_bytes = Bytes.from(


### PR DESCRIPTION
Dead code G2Affine.add removed from src/ec/g2.ts (1a697/a9dea), off-circuit comment added to G2Line.fromPoints in src/lines/index.ts (a9dea), no changes to toBigInt usage in witness blocks or off-circuit code (1a697), changelog updated