### PR TITLE
Fix/audit 1f602: Function `wordToBytes` does not guarantee canonicity for large `bytesPerWord`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,78 @@
+# 5/08/26 - Audit 1f602: Function `wordToBytes` does not guarantee canonicity for large `bytesPerWord`
+
+## Finding 1f602 (verbatim)
+
+The codebase contains two copies of wordToBytes, one in src/sha/sha_hash.ts:66 and one in src/sha/utils.ts:47. Both build the same circuit for Field -> UInt8[], decomposing a value into a little-endian byte array of length bytesPerWord:
+
+```typescript
+// proof-conversion/src/sha/utils.ts
+function wordToBytes(word: Field, bytesPerWord = 8): UInt8[] {
+  let bytes = Provable.witness(Provable.Array(UInt8, bytesPerWord), () => {
+    let w = word.toBigInt();
+    return Array.from({ length: bytesPerWord }, (_, k) =>
+      UInt8.from((w >> BigInt(8 * k)) & 0xffn)
+    );
+  });
+
+  // check decomposition
+  bytesToWord(bytes).assertEquals(word);
+
+  return bytes;
+}
+```
+
+Each witnessed byte is a UInt8, so Provable.witness range-checks it to [0, 255] in-circuit (UInt8.check calls RangeCheck.rangeCheck8). The only other constraint is the reconstruction equality bytesToWord(bytes).assertEquals(word), where:
+
+    bytesToWord(bytes) = sum for k = 0 .. bytesPerWord-1 of ( bytes[k] * 2^(8*k) )
+
+This equality is enforced over the field, i.e. modulo p, the characteristic of Field (the Pallas base field, p ~= 2^254.86, a 255-bit prime). The decomposition is therefore only guaranteed to be canonical if the full range of representable byte arrays cannot wrap around the modulus, that is when
+2^(8 * bytesPerWord) <= p,
+which for the Pallas base field means bytesPerWord <= 31. The function does not assert any bound on bytesPerWord, so it silently relies on every caller passing a small enough value.
+
+If bytesPerWord is large enough that 2^(8 * bytesPerWord) > p (i.e. bytesPerWord >= 32), the reconstruction constraint no longer pins down a unique byte array: multiple distinct UInt8[] values reconstruct to the same word modulo p, and a byte array may reconstruct to a word whose integer value differs from the array's integer value by a multiple of p. In that regime the returned bytes are not a sound big-integer decomposition of word.
+
+Put differently, in this regime the circuit does not implement a function of its input: for a single word there are several distinct byte arrays that all satisfy the constraints, so the decomposition it computes is non-deterministic. Which of the valid outputs is returned is fixed only by the witness generator (the Provable.witness callback), and a malicious prover is free to satisfy the constraint system with any of the other valid byte arrays. Downstream logic that consumes the bytes and assumes they are the unique canonical little-endian representation of word therefore cannot rely on that being the case.
+
+Impact
+
+No soundness or completeness impact has been identified in the audited code. All current call sites pass a bytesPerWord well within the safe range:
+
+- src/sha/sha_hash.ts:100, src/plonk/fiat-shamir/index.ts:573, and src/blobstream/batcher.ts:264 call wordToBytes(x.value, 4) (4 bytes, 32 bits).
+- src/blobstream/verify_blobstream.ts:33 calls wordToBytes(num.toFields()[0]) with the default bytesPerWord = 8 on a UInt64 field, which is bounded to 64 bits.
+
+In each case 2^(8 * bytesPerWord) <= 2^64 << p, so the decomposition is canonical and the missing bound has no effect today.
+
+However, the correctness of the decomposition rests on an invariant that the function neither documents nor enforces.
+Future development could add callers that do not abide by the restriction, or switch to a prime that makes the current calls unsound.
+
+Recommendations
+
+Add an explicit assertion in both copies of wordToBytes that the requested width fits inside the field, so that an out-of-range bytesPerWord throws at circuit-construction time rather than silently producing a non-canonical decomposition.
+
+```typescript
++if (1n << BigInt(8 * bytesPerWord) > Field.ORDER) {
++  throw new Error(
++    `wordToBytes: bytesPerWord=${bytesPerWord} exceeds the field capacity`
++  );
++}
+```
+
+## Response
+
+We agree with the finding, both the wordToBytes function could lead accept multiple distinct UInt8[] values reconstructing a degenerate word modulo p when 2^(8 * bytesPerWord) > p. Moreover we recognise the code duplication as non optimal.
+
+### Commit 1 - Regression test for 1f602
+
+- **Regression test** (`src/sha/1f602_regression.spec.ts`): added `bytesPerWord at the safe bound (2^(8n) <= Field.ORDER) must not throw`, `bytesPerWord one past the safe bound (2^(8n) > Field.ORDER) must throw`, `at the safe bound, wordToBytes round-trips to the original word`, and `default bytesPerWord=8 must not throw`. The safe bound is computed from `Field.ORDER` itself (largest bytesPerWord with `2^(8*bytesPerWord) <= Field.ORDER`) rather than hardcoded, so the test tracks the actual field in use rather than today's specific byte count.
+
+Run: `npm run test:jest -- src/sha/1f602_regression.spec.ts`
+
+Results:
+
+- Regression tests: 1 fail, 3 pass. `wordToBytes` does not throw one byte past the safe bound, confirming the missing guard described in the finding.
+
+---
+
 # 02/07/26 - Audit 1a697 and a9dea: Field.toBigInt debug-only usage and undocumented value-dependence
 
 ## Finding 1a697 (verbatim)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,17 @@ Results:
 
 - Regression tests: 1 fail, 3 pass. `wordToBytes` does not throw one byte past the safe bound, confirming the missing guard described in the finding.
 
+### Commit 2 - Fix applied
+
+- **`src/sha/utils.ts`**: added the compile-time guard `if (1n << BigInt(8 * bytesPerWord) > Field.ORDER) throw ...` at the top of `wordToBytes`, rejecting any `bytesPerWord` for which the byte range could wrap around the field modulus.
+- **`src/sha/sha_hash.ts`**: removed the redundant local copies of `wordToBytes` and `bytesToWord`, now imported from `src/sha/utils.ts` so the guard applies uniformly to every caller.
+
+Run: `npm run test:jest -- src/sha/1f602_regression.spec.ts`
+
+Results:
+
+- Regression tests: 4 pass, 0 fail. `wordToBytes` now throws for any bytesPerWord that would let the byte range wrap around `Field.ORDER`.
+
 ---
 
 # 02/07/26 - Audit 1a697 and a9dea: Field.toBigInt debug-only usage and undocumented value-dependence

--- a/src/sha/1f602_regression.spec.ts
+++ b/src/sha/1f602_regression.spec.ts
@@ -1,0 +1,36 @@
+import { Field } from 'o1js';
+import { bytesToWord, wordToBytes } from './utils.js';
+
+describe('regression_1f602_wordToBytes_canonicity_bound', () => {
+  let maxSafeBytesPerWord: number;
+
+  beforeAll(() => {
+    // Largest bytesPerWord for which 2^(8*bytesPerWord) <= Field.ORDER, i.e.
+    // the last width where the byte range cannot wrap around the field
+    // modulus.
+    maxSafeBytesPerWord = 0;
+    while ((1n << BigInt(8 * (maxSafeBytesPerWord + 1))) <= Field.ORDER) {
+      maxSafeBytesPerWord++;
+    }
+  });
+
+  test('bytesPerWord at the safe bound (2^(8n) <= Field.ORDER) must not throw', () => {
+    expect(() => wordToBytes(Field(0n), maxSafeBytesPerWord)).not.toThrow();
+  });
+
+  test('bytesPerWord one past the safe bound (2^(8n) > Field.ORDER) must throw', () => {
+    expect(() =>
+      wordToBytes(Field(0n), maxSafeBytesPerWord + 1)
+    ).toThrow();
+  });
+
+  test('at the safe bound, wordToBytes round-trips to the original word', () => {
+    const word = Field(123456789n);
+    const bytes = wordToBytes(word, maxSafeBytesPerWord);
+    expect(bytesToWord(bytes).toBigInt()).toBe(word.toBigInt());
+  });
+
+  test('default bytesPerWord=8 must not throw', () => {
+    expect(() => wordToBytes(Field(42n))).not.toThrow();
+  });
+});

--- a/src/sha/sha_hash.ts
+++ b/src/sha/sha_hash.ts
@@ -1,4 +1,5 @@
 import { Bytes, Gadgets, UInt8, Field, UInt32, Provable } from 'o1js';
+import { bytesToWord, wordToBytes } from './utils.js';
 
 /*
 we have 741 bytes to hash: 
@@ -55,27 +56,6 @@ console.log(hash.toHex());
 //96505839157e4f0984258b89bda90c3661bfce8505d34120f2989236f4c576a2
 
 let preimage: UInt8[] = preimageBytes.bytes.concat(padding);
-
-function bytesToWord(wordBytes: UInt8[]): Field {
-  return wordBytes.reduce((acc, byte, idx) => {
-    const shift = 1n << BigInt(8 * idx);
-    return acc.add(byte.value.mul(shift));
-  }, Field.from(0));
-}
-
-function wordToBytes(word: Field, bytesPerWord = 8): UInt8[] {
-  let bytes = Provable.witness(Provable.Array(UInt8, bytesPerWord), () => {
-    let w = word.toBigInt();
-    return Array.from({ length: bytesPerWord }, (_, k) =>
-      UInt8.from((w >> BigInt(8 * k)) & 0xffn)
-    );
-  });
-
-  // check decomposition
-  bytesToWord(bytes).assertEquals(word);
-
-  return bytes;
-}
 
 const chunks: UInt32[] = [];
 

--- a/src/sha/utils.ts
+++ b/src/sha/utils.ts
@@ -39,6 +39,16 @@ function bytesToWord(wordBytes: UInt8[]): Field {
 }
 
 function wordToBytes(word: Field, bytesPerWord = 8): UInt8[] {
+  // Finding 1f602 - if bytesPerWord is large enough that 
+  // 2^(8 * bytesPerWord) > p multiple distinct UInt8[]
+  // values reconstruct to the same word modulo p
+  // Block at circuit compile time
+  if (1n << BigInt(8 * bytesPerWord) > Field.ORDER) {
+    throw new Error(
+      `wordToBytes: bytesPerWord=${bytesPerWord} exceeds the field capacity`
+    );
+  }
+
   let bytes = Provable.witness(Provable.Array(UInt8, bytesPerWord), () => {
     let w = word.toBigInt();
     return Array.from({ length: bytesPerWord }, (_, k) =>


### PR DESCRIPTION
A compile time circuit guard is needed to prevent attempting to use bytesPerWord parameter values which would lead to unsound usage of the utility.

PR commits:

- Documenting issue and adding a regression test https://github.com/Nori-zk/proof-conversion/commit/a087f65e587b85643393380ec973c3d598345860
- Implementing a compile time guard and test results demonstraighting resolution of the issue https://github.com/Nori-zk/proof-conversion/commit/7d49b9be128b1c84aca59ac09ba57a5cf96cc264